### PR TITLE
feat: enable zsync delta updates for AppImage

### DIFF
--- a/.github/actions/build-appimage/action.yml
+++ b/.github/actions/build-appimage/action.yml
@@ -35,4 +35,5 @@ runs:
         chmod +x appimagetool-x86_64.AppImage
         
         # 5. Build AppImage (Extract and run to avoid FUSE issues in CI)
-        ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run AppDir bengal-download-manager-${VERSION}-x86_64.AppImage
+        UPDATE_INFO="gh-releases-zsync|tazihad|bengal-download-manager|latest|bengal-download-manager-*-x86_64.AppImage.zsync"
+        ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run -u "$UPDATE_INFO" AppDir bengal-download-manager-${VERSION}-x86_64.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           files: |
             build_cmake/dist/bengal-download-manager-${{ steps.get_tag.outputs.version }}-x86_64
             bengal-download-manager-${{ steps.get_tag.outputs.version }}-x86_64.AppImage
+            bengal-download-manager-${{ steps.get_tag.outputs.version }}-x86_64.AppImage.zsync
             extension-firefox.xpi
           draft: false
           prerelease: true


### PR DESCRIPTION
## Summary
- Embeds GitHub Release update information into the AppImage using `appimagetool`'s `-u` flag.
- Updates the release workflow to upload the generated `.zsync` file as a release asset.
- Enables delta updates for users downloading via AppImage.

## Test Plan
- Verification subagent confirmed YAML syntax and update info string format.
- Full verification requires a successful GitHub Actions run on a release trigger.
- Embedded update info can be verified with `appimage-extract-and-run --appimage-updateinfo` on the built asset.