### PR TITLE
refactor(ui): reorder startup options and remove browser integration checkbox

### DIFF
--- a/src/ui/dialogs/options.py
+++ b/src/ui/dialogs/options.py
@@ -83,18 +83,14 @@ class OptionsDialog(QDialog):
         vbox_startup.setContentsMargins(10, 15, 10, 10)
         vbox_startup.setSpacing(10)
         
-        self.chk_start_minimized = QCheckBox("Start minimized in system tray on system startup")
-        # Load from parent (MainWindow) settings
-        self.chk_start_minimized.setChecked(getattr(self.parent(), "start_minimized_on_autostart", False))
-        vbox_startup.addWidget(self.chk_start_minimized)
-        
         self.chk_startup = QCheckBox("Launch Bengal DM on system startup")
         self.chk_startup.setChecked(is_autostart_enabled())
         vbox_startup.addWidget(self.chk_startup)
         
-        self.chk_browser = QCheckBox("Integrate into browsers (Coming Soon)")
-        self.chk_browser.setEnabled(False)
-        vbox_startup.addWidget(self.chk_browser)
+        self.chk_start_minimized = QCheckBox("Start minimized in system tray on system startup")
+        # Load from parent (MainWindow) settings
+        self.chk_start_minimized.setChecked(getattr(self.parent(), "start_minimized_on_autostart", False))
+        vbox_startup.addWidget(self.chk_start_minimized)
         
         grp_startup.setLayout(vbox_startup)
         layout.addWidget(grp_startup)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -202,6 +202,32 @@ def test_start_menu_launch_vs_autostart_minimized_flag(monkeypatch):
     assert ("--minimized" in argv_normal) is False
     assert ("--minimized" in argv_minimized) is True
 
+def test_options_dialog_startup_checkbox_ordering_and_browser_removal(qapp):
+    from main import MainWindow
+    from ui.dialogs import OptionsDialog
+
+    window = MainWindow()
+    opt_dlg = OptionsDialog(window)
+
+    # Ensure browser integration checkbox is removed
+    assert not hasattr(opt_dlg, "chk_browser")
+
+    # Ensure Launch Bengal is on top of start minimized
+    assert opt_dlg.chk_startup.text() == "Launch Bengal DM on system startup"
+    assert opt_dlg.chk_start_minimized.text() == "Start minimized in system tray on system startup"
+    
+    # Check widget order in vbox_startup
+    grp_startup = opt_dlg.general_tab.findChild(object, "")
+    # Verify chk_startup comes before chk_start_minimized
+    layout = opt_dlg.chk_startup.parentWidget().layout()
+    startup_idx = layout.indexOf(opt_dlg.chk_startup)
+    minimized_idx = layout.indexOf(opt_dlg.chk_start_minimized)
+    assert startup_idx < minimized_idx
+    assert startup_idx == 0
+
+    opt_dlg.close()
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Reordered options in the General tab's **Startup & Integration** section so that **Launch Bengal DM on system startup** is placed at the top above **Start minimized in system tray on system startup**.
- Removed the placeholder **Integrate into browsers (Coming Soon)** checkbox.
- Added automated unit test verifying layout ordering and browser checkbox removal.

## Verification
- Ran unit test suite (`PYTHONPATH=src venv/bin/pytest -v tests/`), all 25 tests passed cleanly.