### PR TITLE
feat(ui): add UI scale dropdown to Options General tab

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1364,7 +1364,8 @@ class MainWindow(QMainWindow):
                 "geometry": self.saveGeometry().toHex().data().decode(),
                 "windowState": self.saveState().toHex().data().decode(),
                 "column_data": column_data,
-                "start_minimized": getattr(self, "start_minimized_on_autostart", False)
+                "start_minimized": getattr(self, "start_minimized_on_autostart", False),
+                "ui_scale": getattr(self, "settings", {}).get("ui_scale", "100%")
             }
             with open(os.path.join(config_dir, "settings.json"), "w") as f:
                 json.dump(settings, f)
@@ -2415,6 +2416,21 @@ class MainWindow(QMainWindow):
 if __name__ == "__main__":
 
     from PyQt6.QtCore import Qt
+
+    try:
+        from core.utils import get_config_dir
+        _cfg_path = os.path.join(get_config_dir(), "settings.json")
+        if os.path.exists(_cfg_path):
+            with open(_cfg_path, "r") as _f:
+                _s_data = json.load(_f)
+                _scale_str = _s_data.get("ui_scale", "100%")
+                if _scale_str and _scale_str != "100%":
+                    _num_str = _scale_str.replace("%", "").strip()
+                    _factor = float(_num_str) / 100.0
+                    os.environ["QT_SCALE_FACTOR"] = str(_factor)
+    except Exception:
+        pass
+
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     app = QApplication(sys.argv)
     app.setOrganizationName("bengal-download-manager")

--- a/src/ui/dialogs/options.py
+++ b/src/ui/dialogs/options.py
@@ -116,6 +116,46 @@ class OptionsDialog(QDialog):
         
         grp_engine.setLayout(vbox_engine)
         layout.addWidget(grp_engine)
+
+        # 3. UI Settings
+        grp_ui = QGroupBox("UI Settings")
+        vbox_ui = QVBoxLayout()
+        vbox_ui.setContentsMargins(10, 15, 10, 10)
+        vbox_ui.setSpacing(10)
+
+        row_scale = QHBoxLayout()
+        lbl_scale = QLabel("Scale:")
+        lbl_scale.setToolTip("Set user interface scale factor")
+        self.combo_scale = QComboBox()
+        self.combo_scale.setToolTip("Set user interface scale factor")
+        scale_options = [
+            "50%", "75%", "90%", "100%", "110%", "115%", "125%", 
+            "135%", "150%", "175%", "200%", "225%", "250%", "275%", "300%"
+        ]
+        self.combo_scale.addItems(scale_options)
+
+        # Load saved scale setting from parent if available
+        current_scale = "100%"
+        if self.parent() and hasattr(self.parent(), "settings"):
+            current_scale = self.parent().settings.get("ui_scale", "100%")
+        self.initial_scale = current_scale
+
+        idx = self.combo_scale.findText(current_scale)
+        if idx != -1:
+            self.combo_scale.setCurrentIndex(idx)
+        else:
+            def_idx = self.combo_scale.findText("100%")
+            if def_idx != -1:
+                self.combo_scale.setCurrentIndex(def_idx)
+
+        row_scale.addWidget(lbl_scale)
+        row_scale.addWidget(self.combo_scale)
+        row_scale.addStretch()
+        vbox_ui.addLayout(row_scale)
+
+        grp_ui.setLayout(vbox_ui)
+        layout.addWidget(grp_ui)
+
         layout.addStretch()
 
     def refresh_engine_status(self):
@@ -542,9 +582,14 @@ class OptionsDialog(QDialog):
         self.config_data["temp_dir"] = self.txt_temp_path.text()
         save_category_config(self.config_data)
         
-        # Save start_minimized_on_autostart to parent (MainWindow)
+        new_scale = self.combo_scale.currentText()
+        scale_changed = hasattr(self, 'initial_scale') and (self.initial_scale != new_scale)
+
+        # Save start_minimized_on_autostart and ui_scale to parent (MainWindow)
         if self.parent():
             setattr(self.parent(), "start_minimized_on_autostart", self.chk_start_minimized.isChecked())
+            if hasattr(self.parent(), "settings") and isinstance(self.parent().settings, dict):
+                self.parent().settings["ui_scale"] = new_scale
             save_fn = getattr(self.parent(), "save_settings", None)
             if callable(save_fn):
                 save_fn()
@@ -552,6 +597,14 @@ class OptionsDialog(QDialog):
         set_autostart_enabled(self.chk_startup.isChecked(), self.chk_start_minimized.isChecked())
         self.save_proxy_data()
         self.save_extension_data()
+
+        if scale_changed:
+            QMessageBox.information(
+                self,
+                "Restart Required",
+                "UI Scale setting has been changed. Please restart Bengal Download Manager to apply the changes."
+            )
+
         self.accept()
 
     def get_theme(self):

--- a/src/ui/qml/OptionsDialog.qml
+++ b/src/ui/qml/OptionsDialog.qml
@@ -31,6 +31,14 @@ Kirigami.Dialog {
                 value: 4
             }
 
+            Controls.ComboBox {
+                id: comboScale
+                Kirigami.FormData.label: "Scale:"
+                model: ["50%", "75%", "90%", "100%", "110%", "115%", "125%", "135%", "150%", "175%", "200%", "225%", "250%", "275%", "300%"]
+                currentIndex: 3
+                Layout.fillWidth: true
+            }
+
             Controls.TextField {
                 id: txtDefaultDir
                 Kirigami.FormData.label: "Default Downloads Directory:"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -257,6 +257,46 @@ def test_ui_comprehensive_tooltips(qapp):
     assert header_item.toolTip() != ""
     window.close()
 
+def test_options_dialog_ui_scale_dropdown(qapp, tmp_path, monkeypatch):
+    import main
+    import core.utils
+    from PyQt6.QtWidgets import QMessageBox
+    monkeypatch.setattr(main, "get_config_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(core.utils, "get_config_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(QMessageBox, "information", lambda *args, **kwargs: None)
+
+    from main import MainWindow
+    from ui.dialogs import OptionsDialog
+
+    window = MainWindow()
+    opt_dlg = OptionsDialog(window)
+
+    # Check combo_scale existence
+    assert hasattr(opt_dlg, "combo_scale")
+    combo = opt_dlg.combo_scale
+
+    # Check items count and options
+    expected_items = [
+        "50%", "75%", "90%", "100%", "110%", "115%", "125%", 
+        "135%", "150%", "175%", "200%", "225%", "250%", "275%", "300%"
+    ]
+    items = [combo.itemText(i) for i in range(combo.count())]
+    assert items == expected_items
+
+    # Check default selected item
+    assert combo.currentText() == "100%"
+
+    # Select 125% and accept
+    idx_125 = combo.findText("125%")
+    assert idx_125 != -1
+    combo.setCurrentIndex(idx_125)
+
+    opt_dlg.save_and_accept()
+    assert window.settings.get("ui_scale") == "125%"
+
+    opt_dlg.close()
+    window.close()
+
 
 
 


### PR DESCRIPTION
## Description
This PR introduces a UI Scale selection dropdown in **Options -> General Tab -> UI Settings**.

### Features & Changes
- Added Scale dropdown ( / Kirigami ) in General options tab with KDE Plasma style scale presets ( to ).
- Defaults to  for fresh installations while retaining user choices upon update.
- Configured application entry point () to apply  at startup based on saved setting.
- Added prompt informing user to restart application when scale setting is modified.
- Added automated test coverage in  with isolated config directory context.

### Verification
- Ran full test suite (), 28 tests passing.