### PR TITLE
fix(ui): preserve and display download size across app restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,9 @@ build/
 Thumbs.db
 
 # custom
-docs/
-!docs/superpowers/specs/
+docs/*
+!docs/*.md
+!docs/superpowers/
 .superpowers/
 .worktrees/
 .agents/

--- a/docs/COOKIES_GUIDE.md
+++ b/docs/COOKIES_GUIDE.md
@@ -1,0 +1,59 @@
+# How to Export cookies.txt for Bengal Download Manager
+
+This guide explains how to export a Netscape-formatted `cookies.txt` file from your web browser using the open-source **Get cookies.txt LOCALLY** browser extension, and import it into **Bengal Download Manager's Media Downloader**.
+
+---
+
+## 1. Why Are Cookies Needed?
+
+Video streaming platforms like YouTube use bot detection algorithms, login gates, and throttling mechanisms. Providing an authenticated `cookies.txt` file helps:
+
+- **Bypass "Sign in to confirm you're not a bot" errors**: Download age-restricted, subscriber-only, or rate-limited content.
+- **Access High Quality Streams**: Unlock premium or restricted stream formats (such as 4K/1080p Premium bitrates).
+- **Download Private or Unlisted Playlists**: Access your personal saved playlists and member content.
+
+> **Security Note:**
+> Bengal Download Manager processes `cookies.txt` **100% locally** on your machine via `yt-dlp`. Cookies are never transmitted to external servers or third parties. Keep your `cookies.txt` secure and never share it publicly.
+
+---
+
+## 2. Install the "Get cookies.txt LOCALLY" Extension
+
+**Get cookies.txt LOCALLY** is a secure, open-source browser extension that exports cookies in standard Netscape format without sending data to any cloud service.
+
+* **GitHub Repository:** [kairi003/Get-cookies.txt-Locally](https://github.com/kairi003/Get-cookies.txt-Locally)
+* **Chrome Web Store:** [Get cookies.txt LOCALLY (Chrome/Chromium/Brave/Edge)](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
+* **Firefox Add-ons:** [Get cookies.txt LOCALLY (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/get-cookies-txt-locally/)
+
+Install the extension for your preferred browser using the links above.
+
+---
+
+## 3. Export cookies.txt from Your Browser
+
+1. Open your browser and navigate to the target website (e.g., [YouTube](https://www.youtube.com)).
+2. Make sure you are logged in to your account.
+3. Click the **Extensions** icon (puzzle piece) in your browser toolbar, then click **Get cookies.txt LOCALLY**.
+4. In the popup window:
+   - Select **Export Current Tab** (or **Export All Cookies**).
+   - Click the **Export** button.
+5. Save the generated `cookies.txt` (e.g. `youtube.com_cookies.txt`) in a convenient local directory (e.g., `~/Downloads` or `~/.config/bengal-download-manager/`).
+
+---
+
+## 4. Import cookies.txt into Bengal Download Manager
+
+1. Open **Bengal Download Manager**.
+2. Launch the **Media Downloader** (`Ctrl+M` or click the **Media Downloader** button on the toolbar).
+3. Click the **Gear / Settings** icon (`⚙`) next to the *Analyze Link* button to expand the **Cookies Authentication** panel.
+4. Click **Browse...** next to **cookies.txt Path** and select your exported `.txt` file.
+5. The path is saved persistently across app restarts.
+6. Paste your media or playlist URL and click **Analyze Link** — `yt-dlp` will now authenticate seamlessly using your exported cookies.
+
+---
+
+## 5. Tips & Troubleshooting
+
+- **Expired Sessions:** Cookies naturally expire after days or weeks depending on the service. If you encounter authentication errors, re-export fresh cookies from your browser.
+- **Multiple Accounts/Domains:** You can export separate cookie files for different domains (e.g. `youtube.com`, `bilibili.com`, `vimeo.com`) and switch them in the Media Downloader settings as needed.
+- **Clear Cookies:** To reset authentication, open the Media Downloader cookies panel and click the **Clear** button.

--- a/docs/MEDIA_DOWNLOADER.md
+++ b/docs/MEDIA_DOWNLOADER.md
@@ -39,7 +39,16 @@ The **Media Downloader** feature in Bengal Download Manager allows users to extr
 
 ---
 
-## 3. Usage Instructions
+## 3. Cookies Authentication
+
+For age-restricted videos, private playlists, or restricted streams:
+1. Click the **Gear / Settings** icon (`⚙`) next to *Analyze Link* to expand the **Cookies Authentication** panel.
+2. Select your exported `cookies.txt` file (see [How to Export cookies.txt Guide](COOKIES_GUIDE.md)).
+3. `yt-dlp` automatically loads the cookies file locally to authenticate requests.
+
+---
+
+## 4. Usage Instructions
 
 1. Launch Bengal Download Manager (`python src/main.py`).
 2. Click the **Media Downloader** button on the main toolbar (right of **Options**).

--- a/src/main.py
+++ b/src/main.py
@@ -2195,6 +2195,14 @@ class MainWindow(QMainWindow):
                 path = item_name.data(Qt.ItemDataRole.UserRole + 1) 
                 filename = item_name.text()
                 size = safe_get(1)
+                if (not size or size in ["Unknown", "?", "Calculating...", "0 B", "0.00 B"]) and path and os.path.exists(path) and os.path.isfile(path):
+                    try:
+                        file_sz = os.path.getsize(path)
+                        if file_sz > 0:
+                            size = format_bytes(file_sz)
+                            self._set_sortable_item(row, 1, size, parse_size_to_bytes)
+                    except Exception:
+                        pass
                 # Use standardized internal status if available, otherwise fallback to text
                 status_item = self.download_table.item(row, 2)
                 internal_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
@@ -2285,10 +2293,21 @@ class MainWindow(QMainWindow):
                 
                 self.download_table.setItem(row, 0, item_name)
                 
+                # Col 1: Size
+                file_path = d.get("path", "")
+                saved_size = d.get("size", "")
+                if (not saved_size or saved_size in ["Unknown", "?", "Calculating...", "0 B", "0.00 B"]) and file_path and os.path.exists(file_path) and os.path.isfile(file_path):
+                    try:
+                        file_sz = os.path.getsize(file_path)
+                        if file_sz > 0:
+                            saved_size = format_bytes(file_sz)
+                    except Exception:
+                        pass
+                self._set_sortable_item(row, 1, saved_size if saved_size else "Unknown", parse_size_to_bytes)
+                
                 # Col 2: Status (Sanitize: show percentage, never "Paused")
                 raw_status = d.get("status", "0.00%")
                 display_status = raw_status
-                file_path = d.get("path", "")
                 
                 # Determine internal state based on status text and file existence
                 is_actually_complete = False
@@ -3636,6 +3655,14 @@ class MainWindow(QMainWindow):
             if display_status == "Complete":
                 final_display = "Complete"
                 status_item.setData(Qt.ItemDataRole.UserRole, "Complete")
+                path = item_ref.data(Qt.ItemDataRole.UserRole + 1)
+                if path and os.path.exists(path) and os.path.isfile(path):
+                    try:
+                        actual_sz = os.path.getsize(path)
+                        if actual_sz > 0:
+                            self._set_sortable_item(row, 1, format_bytes(actual_sz), parse_size_to_bytes)
+                    except Exception:
+                        pass
             elif display_status in ["Paused", "Cancelled"]:
                 pct = status_item.data(Qt.ItemDataRole.UserRole)
                 final_display = pct if pct else "0.00%"

--- a/src/ui/dialogs/media_downloader.py
+++ b/src/ui/dialogs/media_downloader.py
@@ -249,8 +249,13 @@ class MediaDownloaderDialog(QDialog):
         manual_path_layout.addWidget(self.btn_clear_cookies)
         cookies_layout.addLayout(manual_path_layout)
 
-        self.lbl_cookies_info = QLabel("🔒 Cookies are read locally, never shared")
-        self.lbl_cookies_info.setStyleSheet("color: gray; font-size: 11px; font-style: italic;")
+        self.lbl_cookies_info = QLabel(
+            '🔒 Cookies are read locally, never shared. • <a href="https://github.com/tazihad/bengal-download-manager/blob/main/docs/COOKIES_GUIDE.md" style="color: palette(highlight); text-decoration: underline;">How to export cookies.txt guide</a>'
+        )
+        self.lbl_cookies_info.setStyleSheet("font-size: 11px;")
+        self.lbl_cookies_info.setTextFormat(Qt.TextFormat.RichText)
+        self.lbl_cookies_info.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
+        self.lbl_cookies_info.setOpenExternalLinks(True)
         cookies_layout.addWidget(self.lbl_cookies_info)
 
         main_layout.addWidget(self.frame_cookies_prefs)

--- a/src/ui/dialogs/media_downloader.py
+++ b/src/ui/dialogs/media_downloader.py
@@ -206,19 +206,24 @@ class MediaDownloaderDialog(QDialog):
 
         # 2b. Cookies & Authentication Preferences Panel (Toggled via 3-dot button)
         self.frame_cookies_prefs = QFrame()
-        self.frame_cookies_prefs.setFrameShape(QFrame.Shape.StyledPanel)
+        self.frame_cookies_prefs.setObjectName("cookiesPrefsFrame")
+        self.frame_cookies_prefs.setFrameShape(QFrame.Shape.NoFrame)
         self.frame_cookies_prefs.setStyleSheet("""
-            QFrame {
+            QFrame#cookiesPrefsFrame {
                 background-color: palette(alternate-base);
                 border: 1px solid palette(mid);
-                border-radius: 6px;
+                border-radius: 8px;
+            }
+            QFrame#cookiesPrefsFrame QLabel {
+                background: transparent;
+                border: none;
             }
         """)
         self.frame_cookies_prefs.hide()
 
         cookies_layout = QVBoxLayout(self.frame_cookies_prefs)
-        cookies_layout.setContentsMargins(10, 8, 10, 8)
-        cookies_layout.setSpacing(6)
+        cookies_layout.setContentsMargins(12, 10, 12, 10)
+        cookies_layout.setSpacing(8)
 
         lbl_cookies_header = QLabel("Cookies Authentication (cookies.txt)")
         font_c = QFont()
@@ -231,6 +236,7 @@ class MediaDownloaderDialog(QDialog):
         lbl_manual_path = QLabel("cookies.txt Path:")
         self.txt_cookies_path = QLineEdit()
         self.txt_cookies_path.setPlaceholderText("Select path to cookies.txt file...")
+        self.txt_cookies_path.setFixedHeight(28)
         self.txt_cookies_path.textChanged.connect(self._save_cookies_path_permanently)
 
         self.btn_browse_cookies = QPushButton("Browse...")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -562,8 +562,44 @@ def test_download_complete_persistence_on_restart(qapp, tmp_path, monkeypatch):
     win2.hide()
     assert win2.download_table.rowCount() == 1
     assert win2.download_table.item(0, 0).text() == "finished_movie.mp4"
+    assert win2.download_table.item(0, 1) is not None
+    assert win2.download_table.item(0, 1).text() == "100.00 KB"
     assert win2.download_table.item(0, 2).text() == "Complete"
     assert win2.download_table.item(0, 2).data(Qt.ItemDataRole.UserRole + 1) == "Complete"
+
+
+def test_download_size_displayed_all_time(qapp, tmp_path):
+    target_file = tmp_path / "sample.iso"
+    target_file.write_bytes(b"x" * 2048)
+
+    win = MainWindow(start_ipc=False)
+    win.hide()
+    win.download_table.setRowCount(0)
+
+    win.start_download(
+        url="http://example.com/sample.iso",
+        custom_save_dir=str(tmp_path),
+        start_paused=True,
+        show_dialog=False
+    )
+    item_ref = win.download_table.item(0, 0)
+    item_ref.setData(Qt.ItemDataRole.UserRole + 1, str(target_file))
+
+    win.download_finished(item_ref, "Complete")
+
+    # Table size must be displayed
+    assert win.download_table.item(0, 1) is not None
+    assert win.download_table.item(0, 1).text() == "2.00 KB"
+
+    # Save and reload
+    win.save_data()
+
+    reloaded_win = MainWindow(start_ipc=False)
+    reloaded_win.hide()
+    assert reloaded_win.download_table.rowCount() == 1
+    assert reloaded_win.download_table.item(0, 1) is not None
+    assert reloaded_win.download_table.item(0, 1).text() == "2.00 KB"
+    assert reloaded_win.download_table.item(0, 2).text() == "Complete"
 
 
 def test_download_progress_dialog_close_after_complete(qapp, tmp_path):


### PR DESCRIPTION
### Summary
- Populates Column 1 (Size) in `MainWindow.load_data` when restoring items from `downloads.json`.
- Adds disk file size fallbacks to `save_data` and `download_finished` if size is unpopulated or in transient state.
- Adds regression test `test_download_size_displayed_all_time` in `tests/test_ui.py`.