### PR TITLE
fix(ui): ensure DownloadCompleteDialog displays after download completion

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2612,7 +2612,7 @@ class MainWindow(QMainWindow):
         # Track the dialog to prevent garbage collection and allow cleanup
         dialog_id = self._get_item_key(item_ref)
         self.active_file_info_dialogs[dialog_id] = dialog
-        dialog.finished.connect(lambda d_id=dialog_id: self.active_file_info_dialogs.pop(d_id, None))
+        dialog.finished.connect(lambda *_, d_id=dialog_id: self.active_file_info_dialogs.pop(d_id, None))
 
         # Connect signals to handle the dialog result
         dialog.accepted.connect(lambda: self._handle_download_dialog_accepted(dialog, file_info, item_ref))
@@ -2626,6 +2626,8 @@ class MainWindow(QMainWindow):
     def _handle_download_dialog_accepted(self, dialog, file_info, item_ref):
         results = dialog.get_results()
         key = self._get_item_key(item_ref)
+        if key:
+            self.active_file_info_dialogs.pop(key, None)
         
         # Update filename and path in case user changed them in the dialog
         item_ref.setText(results["filename"])
@@ -2650,6 +2652,9 @@ class MainWindow(QMainWindow):
             self._set_status_text(row, "Paused")
 
     def _handle_download_dialog_rejected(self, item_ref):
+        key = self._get_item_key(item_ref)
+        if key:
+            self.active_file_info_dialogs.pop(key, None)
         # User cancelled - remove the proposed download from the table
         row = self.download_table.row(item_ref)
         if row != -1:
@@ -2806,7 +2811,7 @@ class MainWindow(QMainWindow):
         # Use persistent item key to manage active dialogs
         key = self._get_item_key(item_ref)
         self.active_downloads[key] = progress_dialog
-        progress_dialog.finished.connect(lambda k=key: self.active_downloads.pop(k, None))
+        progress_dialog.finished.connect(lambda *_, k=key: self.active_downloads.pop(k, None))
         progress_dialog.finished.connect(self._try_start_queued)
 
         # Trigger UI Update for Stop Buttons
@@ -3371,6 +3376,8 @@ class MainWindow(QMainWindow):
         # Handle UI Popups / Dialogs
         if key in self.active_downloads:
             dlg = self.active_downloads.pop(key, None)
+            if hasattr(dlg, 'is_completed') and display_status == "Complete":
+                dlg.is_completed = True
             if hasattr(dlg, 'close'):
                 dlg.close()
             MemoryGuard.safe_delete_later(dlg)
@@ -3410,7 +3417,7 @@ class MainWindow(QMainWindow):
             # Top-level window (parent=None) sharing app WM_CLASS so it stacks under single app launcher icon
             dialog = DownloadCompleteDialog(file_data, None)
             self.active_complete_dialogs[key] = dialog
-            dialog.finished.connect(lambda: self.active_complete_dialogs.pop(key, None))
+            dialog.finished.connect(lambda *_, k=key: self.active_complete_dialogs.pop(k, None))
             dialog.show()
             
         self.update_status_bar_speed()
@@ -3430,7 +3437,7 @@ class MainWindow(QMainWindow):
         # Top-level window (parent=None) sharing app WM_CLASS so it appears as a separate icon in taskbar panel
         self._options_dlg = OptionsDialog(main_window=self)
         self._options_dlg.accepted.connect(self._handle_options_accepted)
-        self._options_dlg.finished.connect(lambda: setattr(self, "_options_dlg", None))
+        self._options_dlg.finished.connect(lambda *_: setattr(self, "_options_dlg", None))
         self._options_dlg.show()
         self._options_dlg.raise_()
         self._options_dlg.activateWindow()
@@ -3451,7 +3458,7 @@ class MainWindow(QMainWindow):
                         self._media_downloader_dlg._on_analyze_or_stop_clicked()
             return
         self._media_downloader_dlg = MediaDownloaderDialog(main_window=self)
-        self._media_downloader_dlg.finished.connect(lambda: setattr(self, "_media_downloader_dlg", None))
+        self._media_downloader_dlg.finished.connect(lambda *_: setattr(self, "_media_downloader_dlg", None))
         if not auto_start:
             self._media_downloader_dlg.show()
             self._media_downloader_dlg.raise_()
@@ -3473,7 +3480,7 @@ class MainWindow(QMainWindow):
         # Pass the persistent queue list so reopening the dialog preserves all queues
         self._scheduler_dlg = SchedulerDialog(main_window=self, initial_queues=self._queues_data)
         self._scheduler_dlg.finished.connect(self._sync_sidebar_queues)
-        self._scheduler_dlg.finished.connect(lambda: setattr(self, "_scheduler_dlg", None))
+        self._scheduler_dlg.finished.connect(lambda *_: setattr(self, "_scheduler_dlg", None))
         self._scheduler_dlg.show()
         self._scheduler_dlg.raise_()
         self._scheduler_dlg.activateWindow()
@@ -3596,6 +3603,34 @@ class MainWindow(QMainWindow):
                     status_item.setData(Qt.ItemDataRole.UserRole + 1, "Complete")
                 self._set_sortable_item(row, 3, "", parse_time_to_sec)
                 self._set_sortable_item(row, 4, "", parse_size_to_bytes)
+
+                # Dispatch XDG system notification if enabled
+                if getattr(self, "system_notifications", False) or (isinstance(getattr(self, "settings", {}), dict) and self.settings.get("system_notifications", False)):
+                    try:
+                        from core.notifications import send_system_notification
+                        size_str = self.download_table.item(row, 1).text() if self.download_table.item(row, 1) else ""
+                        body = f"{filename} ({size_str})" if size_str and size_str != "?" else filename
+                        send_system_notification(
+                            title="Download Complete",
+                            message=body,
+                            app_name="Bengal Download Manager",
+                            icon_name="io.github.tazihad.bengal-download-manager",
+                            file_path=path,
+                            tray_icon=getattr(self, "tray_icon", None)
+                        )
+                    except Exception:
+                        pass
+
+                # Show IDM-style Download Complete Dialog
+                file_data = {
+                    "url": item_ref.data(Qt.ItemDataRole.UserRole),
+                    "path": path,
+                    "size": self.download_table.item(row, 1).text() if row != -1 else "?"
+                }
+                dialog = DownloadCompleteDialog(file_data, None)
+                self.active_complete_dialogs[key] = dialog
+                dialog.finished.connect(lambda *_, k=key: self.active_complete_dialogs.pop(k, None))
+                dialog.show()
             else:
                 status_item = self.download_table.item(row, 2)
                 if status_item:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1366,6 +1366,80 @@ def test_tray_hibernation_buffers_updates_and_suspends_timers(qapp):
     window.close()
 
 
+def test_download_complete_dialog_shown_after_file_info_fetched(qapp, tmp_path):
+    target_file = tmp_path / "archive.zip"
+    target_file.write_bytes(b"PK\x03\x04" + b"0" * 1024)
+
+    window = MainWindow(start_ipc=False)
+    window.hide()
+
+    file_info = {
+        "url": "http://example.com/archive.zip",
+        "suggested_filename": "archive.zip",
+        "size_str": "1.00 KB",
+        "size_bytes": 1028
+    }
+    window.on_file_info_fetched(file_info)
+
+    assert len(window.active_file_info_dialogs) == 1
+    dlg_key = list(window.active_file_info_dialogs.keys())[0]
+    info_dlg = window.active_file_info_dialogs[dlg_key]
+
+    # Simulate user confirming "Start Download"
+    info_dlg.on_start()
+
+    # Active file info dialog must be cleanly evicted from tracking
+    assert dlg_key not in window.active_file_info_dialogs
+    assert len(window.active_file_info_dialogs) == 0
+
+    # Ensure download item exists and download is marked complete
+    item_ref = window.download_table.item(0, 0)
+    assert item_ref is not None
+    item_ref.setData(Qt.ItemDataRole.UserRole + 1, str(target_file))
+
+    window.download_finished(item_ref, "Complete")
+
+    # Complete dialog must be created and shown
+    assert dlg_key in window.active_complete_dialogs
+    complete_dlg = window.active_complete_dialogs[dlg_key]
+    assert complete_dlg is not None
+    assert complete_dlg.isVisible()
+
+    # Closing dialog cleans up tracking
+    complete_dlg.accept()
+    assert dlg_key not in window.active_complete_dialogs
+    window.close()
+
+
+def test_media_download_complete_dialog_shown(qapp, tmp_path):
+    media_file = tmp_path / "video.mp4"
+    media_file.write_bytes(b"\x00\x00\x00 ftypisom" + b"0" * 2048)
+
+    window = MainWindow(start_ipc=False)
+    window.hide()
+
+    item_name = window.start_media_download(
+        url="https://www.youtube.com/watch?v=sample123",
+        filename="video.mp4",
+        custom_save_dir=str(tmp_path)
+    )
+    key = window._get_item_key(item_name)
+    assert key in window.active_downloads
+
+    # Simulate media download finish
+    window._on_media_download_finished(key, item_name, str(media_file))
+
+    assert key in window.active_complete_dialogs
+    complete_dlg = window.active_complete_dialogs[key]
+    assert complete_dlg is not None
+    assert complete_dlg.isVisible()
+
+    complete_dlg.accept()
+    assert key not in window.active_complete_dialogs
+    window.close()
+
+
+
 
 
 


### PR DESCRIPTION
## Summary
Fixes an issue where `DownloadCompleteDialog` was not being displayed after downloads finished.

## Root Cause
- In `MainWindow.on_file_info_fetched`, `dialog.finished.connect(lambda d_id=dialog_id: ...)` bound `d_id` as the 1st positional argument.
- PyQt6 signal `QDialog.finished(int)` passes the exit code `1` or `0` into `d_id`, evaluating to `self.active_file_info_dialogs.pop(1, None)` instead of the dialog UUID string.
- `dialog_id` remained in `self.active_file_info_dialogs`.
- When `MainWindow.download_finished` was called upon completion, `if key in self.active_file_info_dialogs: return` triggered an early return, blocking `DownloadCompleteDialog` from showing.

## Changes
- Fixed lambda argument capture across `active_file_info_dialogs`, `active_downloads`, and `active_complete_dialogs` using `lambda *_, k=key: ...`.
- Explicitly cleared `self.active_file_info_dialogs` in `_handle_download_dialog_accepted` and `_handle_download_dialog_rejected`.
- Set `dlg.is_completed = True` before programmatic progress dialog closure to avoid spurious paused signals.
- Added `DownloadCompleteDialog` and system notification dispatch in `_on_media_download_finished`.
- Added unit tests covering the full file info fetch -> complete dialog and media download complete dialog flows.

## Verification
- All 137 unit tests passing via `pytest`.