### PR TITLE
feat(options): add configurable split connections and improve details table responsiveness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Download Build Artifacts
@@ -212,6 +214,7 @@ jobs:
           tag = os.environ.get("TAG", "")
           base_url = os.environ.get("BASE_URL", "")
           version = os.environ.get("VERSION", "")
+          repo = os.environ.get("REPOSITORY", "tazihad/bengal-download-manager")
 
           files = [f for f in sorted(os.listdir(".")) if os.path.isfile(f) and f not in ("SHA256SUMS.txt",)]
 
@@ -244,6 +247,15 @@ jobs:
               lines.append(f"| {label} | [{fname}]({url}) |")
           lines.append(f"| 📄 **SHA-256 Checksums** | [SHA256SUMS.txt]({base_url}/SHA256SUMS.txt) |")
           lines.append("\n---\n")
+          
+          is_stable = not any(k in tag.lower() for k in ("alpha", "beta", "rc", "dev"))
+          if is_stable:
+              lines.append("### 🛡️ Supply Chain Security & Artifact Attestation\n")
+              lines.append("Every artifact in this release is signed and attested via GitHub Artifact Attestations (Sigstore).\n")
+              lines.append("Verify the provenance of any downloaded binary with the GitHub CLI:\n```bash")
+              lines.append(f"gh attestation verify <downloaded-file> --repo {repo}")
+              lines.append("```\n\n---\n")
+
           lines.append("### 🔒 Checksums (SHA-256)\n```text")
           
           if os.path.exists("SHA256SUMS.txt"):
@@ -256,6 +268,12 @@ jobs:
           EOF
 
           cd ..
+
+      - name: Generate Artifact Attestation for Stable Release
+        if: ${{ !(contains(needs.prepare.outputs.tag, 'alpha') || contains(needs.prepare.outputs.tag, 'beta') || contains(needs.prepare.outputs.tag, 'rc') || contains(needs.prepare.outputs.tag, 'dev') || inputs.is_prerelease) }}
+        uses: actions/attest@v4
+        with:
+          subject-path: 'release_dist/*'
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -276,7 +276,16 @@ def load_extension_config():
     if os.path.exists(path):
         try:
             with open(path, "r") as f:
-                return json.load(f)
+                loaded = json.load(f)
+                if isinstance(loaded, dict):
+                    merged = default.copy()
+                    merged.update(loaded)
+                    try:
+                        conn = int(merged.get("max_connections", 8))
+                        merged["max_connections"] = max(1, min(32, conn))
+                    except (ValueError, TypeError):
+                        merged["max_connections"] = 8
+                    return merged
         except: pass
     return default
 

--- a/src/core/workers/aria2.py
+++ b/src/core/workers/aria2.py
@@ -127,25 +127,17 @@ class Aria2Worker(QThread):
             if total_length > 0 and completed_length >= total_length:
                 state = "complete"
 
-            if getattr(self, 'is_pause_requested', False):
+            if getattr(self, 'is_pause_requested', False) or getattr(self, 'is_paused', False):
                 download_speed = 0
                 state = "paused"
+                display_state = "Paused"
             elif getattr(self, 'is_resuming', False):
                 if state in ("paused", "waiting"):
                     state = "active"
+                    display_state = "Resuming..."
                 else:
                     self.is_resuming = False
-
-            self.main_bar_signal.emit(completed_length, total_length)
-
-            time_left = 0
-            if download_speed > 0 and total_length > 0:
-                time_left = (total_length - completed_length) / download_speed
-
-            if getattr(self, 'is_resuming', False):
-                display_state = "Resuming..."
-            elif state == "paused":
-                display_state = "Paused"
+                    display_state = "Receiving data..."
             elif state == "complete":
                 display_state = "Complete"
             elif state == "error":
@@ -154,6 +146,12 @@ class Aria2Worker(QThread):
                 display_state = "Cancelled"
             else:
                 display_state = "Receiving data..."
+
+            self.main_bar_signal.emit(completed_length, total_length)
+
+            time_left = 0
+            if download_speed > 0 and total_length > 0:
+                time_left = (total_length - completed_length) / download_speed
 
             self.main_progress_signal.emit(self.row_index, (
                 self.filename,

--- a/src/core/workers/aria2.py
+++ b/src/core/workers/aria2.py
@@ -50,6 +50,9 @@ class Aria2Worker(QThread):
             try: os.makedirs(self.working_dir, exist_ok=True)
             except: self.working_dir = self.save_dir
 
+        self.target_path = self.target_path
+        self.generation = 0
+
     def call_rpc(self, method, params=None):
         return call_aria2_rpc(method, params=params, port=self.rpc_port, token=self.rpc_token)
 
@@ -161,7 +164,8 @@ class Aria2Worker(QThread):
                 f"{self.format_bytes(download_speed, precision=2, pad=False)}/s",
                 completed_length,
                 total_length,
-                download_speed
+                download_speed,
+                getattr(self, 'generation', 0)
             ))
 
             current_time = time.time()

--- a/src/core/workers/aria2.py
+++ b/src/core/workers/aria2.py
@@ -131,9 +131,8 @@ class Aria2Worker(QThread):
                 download_speed = 0
                 state = "paused"
             elif getattr(self, 'is_resuming', False):
-                if state == "paused":
+                if state in ("paused", "waiting"):
                     state = "active"
-                    display_state = "Resuming..."
                 else:
                     self.is_resuming = False
 
@@ -143,11 +142,18 @@ class Aria2Worker(QThread):
             if download_speed > 0 and total_length > 0:
                 time_left = (total_length - completed_length) / download_speed
 
-            display_state = "Receiving data..."
-            if state == "paused": display_state = "Paused"
-            elif state == "complete": display_state = "Complete"
-            elif state == "error": display_state = "Error"
-            elif state == "removed": display_state = "Cancelled"
+            if getattr(self, 'is_resuming', False):
+                display_state = "Resuming..."
+            elif state == "paused":
+                display_state = "Paused"
+            elif state == "complete":
+                display_state = "Complete"
+            elif state == "error":
+                display_state = "Error"
+            elif state == "removed":
+                display_state = "Cancelled"
+            else:
+                display_state = "Receiving data..."
 
             self.main_progress_signal.emit(self.row_index, (
                 self.filename,

--- a/src/core/workers/download.py
+++ b/src/core/workers/download.py
@@ -4,7 +4,7 @@ import json
 from urllib.parse import urlparse, unquote
 import urllib.request
 from PyQt6.QtCore import QThread, pyqtSignal, QMutex
-from core.utils import get_unique_filepath, resolve_filename
+from core.utils import get_unique_filepath, resolve_filename, load_extension_config
 from core.memory_guard import MemoryGuard
 
 class SegmentWorker(QThread):
@@ -221,7 +221,10 @@ class DownloadWorker(QThread):
             
             segments_info = []
             is_resuming = False
-            num_threads = 8
+            
+            ext_data = load_extension_config()
+            max_conn = ext_data.get("max_connections", 8)
+            num_threads = max(1, min(32, int(max_conn))) if isinstance(max_conn, (int, float, str)) and str(max_conn).isdigit() else 8
 
             if os.path.exists(self.state_file) and os.path.exists(self.save_path):
                 try:

--- a/src/core/workers/download.py
+++ b/src/core/workers/download.py
@@ -320,7 +320,8 @@ class DownloadWorker(QThread):
                     f"{self.format_bytes(total_speed, precision=2, pad=False)}/s",
                     total_dl,
                     total_size,
-                    total_speed
+                    total_speed,
+                    getattr(self, 'generation', 0)
                 ))
 
                 save_counter += 1

--- a/src/ui/dialogs/options.py
+++ b/src/ui/dialogs/options.py
@@ -275,6 +275,23 @@ class OptionsDialog(QDialog):
         self.lbl_engine.setToolTip("Connection status of backend Aria2 download engine")
         vbox_engine.addWidget(self.lbl_engine)
         
+        # Max Split Connections (threads)
+        row_conn = QHBoxLayout()
+        lbl_conn = QLabel("Max Split Connections (threads):")
+        lbl_conn.setToolTip("Default number of parallel split connections / threads per download (1-32). Default: 8")
+        self.spin_max_conn = QSpinBox()
+        self.spin_max_conn.setRange(1, 32)
+        init_conn = 8
+        if hasattr(self, "extension_data") and isinstance(self.extension_data, dict):
+            init_conn = self.extension_data.get("max_connections", 8)
+        self.spin_max_conn.setValue(int(init_conn) if isinstance(init_conn, (int, float, str)) and str(init_conn).isdigit() else 8)
+        self.spin_max_conn.setFixedWidth(70)
+        self.spin_max_conn.setToolTip("Default number of parallel split connections / threads per download (1-32). Default: 8")
+        row_conn.addWidget(lbl_conn)
+        row_conn.addWidget(self.spin_max_conn)
+        row_conn.addStretch()
+        vbox_engine.addLayout(row_conn)
+
         # Initial check
         self.refresh_engine_status()
         
@@ -860,12 +877,36 @@ class OptionsDialog(QDialog):
         save_proxy_config(self.proxy_data)
 
     def save_extension_data(self):
+        max_c = 8
+        if hasattr(self, "spin_max_conn"):
+            max_c = self.spin_max_conn.value()
+        elif hasattr(self, "extension_data") and isinstance(self.extension_data, dict):
+            max_c = self.extension_data.get("max_connections", 8)
+
+        proto = "ws"
+        if hasattr(self, "combo_aria_proto"):
+            proto = self.combo_aria_proto.currentData()
+        elif hasattr(self, "extension_data") and isinstance(self.extension_data, dict):
+            proto = self.extension_data.get("protocol", "ws")
+
+        port = 56800
+        if hasattr(self, "spin_aria_port"):
+            port = self.spin_aria_port.value()
+        elif hasattr(self, "extension_data") and isinstance(self.extension_data, dict):
+            port = self.extension_data.get("port", 56800)
+
+        token = ""
+        if hasattr(self, "txt_aria_token"):
+            token = self.txt_aria_token.text().strip()
+        elif hasattr(self, "extension_data") and isinstance(self.extension_data, dict):
+            token = self.extension_data.get("token", "")
+
         self.extension_data = {
-            "protocol": self.combo_aria_proto.currentData(), 
+            "protocol": proto, 
             "host": "localhost",
-            "port": self.spin_aria_port.value(),
-            "token": self.txt_aria_token.text().strip(),
-            "max_connections": 8
+            "port": port,
+            "token": token,
+            "max_connections": max_c
         }
         save_extension_config(self.extension_data)
 

--- a/src/ui/dialogs/progress.py
+++ b/src/ui/dialogs/progress.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont
-from core.utils import show_in_folder
+from core.utils import show_in_folder, load_extension_config
 from core.memory_guard import MemoryGuard
 
 class DownloadProgressDialog(QDialog):
@@ -38,7 +38,10 @@ class DownloadProgressDialog(QDialog):
         self.worker.segment_update_signal.connect(self.update_segment_row)
 
         self.setup_ui()
-        self.init_segment_table(8)
+        
+        ext_data = load_extension_config()
+        initial_conn = ext_data.get("max_connections", 8)
+        self.init_segment_table(int(initial_conn) if isinstance(initial_conn, (int, float, str)) and str(initial_conn).isdigit() else 8)
         self.worker.start()
 
     def setup_status_tab(self):

--- a/src/ui/dialogs/progress.py
+++ b/src/ui/dialogs/progress.py
@@ -335,7 +335,7 @@ class DownloadProgressDialog(QDialog):
             self.segments_layout.itemAt(i).widget().setParent(None)
         self.segment_bars = []
 
-        total_display = 8
+        total_display = max(1, num_segments)
 
         for i in range(total_display):
             bar = QProgressBar()

--- a/src/ui/dialogs/progress.py
+++ b/src/ui/dialogs/progress.py
@@ -335,7 +335,7 @@ class DownloadProgressDialog(QDialog):
             self.segments_layout.itemAt(i).widget().setParent(None)
         self.segment_bars = []
 
-        total_display = max(1, num_segments)
+        total_display = max(8, num_segments)
 
         for i in range(total_display):
             bar = QProgressBar()

--- a/src/ui/dialogs/progress.py
+++ b/src/ui/dialogs/progress.py
@@ -310,9 +310,9 @@ class DownloadProgressDialog(QDialog):
             self.btn_details.setText("Details <<")
             row_height = 20
             self.seg_table.verticalHeader().setDefaultSectionSize(row_height)
-            num_rows = self.seg_table.rowCount()
             header_height = 25
-            table_height = header_height + (row_height * num_rows) + 2
+            visible_rows = min(8, self.seg_table.rowCount())
+            table_height = header_height + (row_height * visible_rows) + 2
             self.seg_table.setFixedHeight(table_height)
             
             # Expand window vertically while keeping width 520

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1711,6 +1711,7 @@ class MainWindow(QMainWindow):
                 worker = getattr(entry, "worker", entry)
                 if getattr(worker, "is_paused", False) or getattr(worker, "is_pause_requested", False):
                     return False
+                return True
             except (RuntimeError, AttributeError, Exception):
                 pass
         try:
@@ -2834,6 +2835,9 @@ class MainWindow(QMainWindow):
                                 dialog.worker.resume()
                         except (RuntimeError, Exception):
                             pass
+                        self._set_status_text(row, "Resuming...", logic_status="Resuming...")
+                        if status_item:
+                            status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
                     
                     try:
                         dialog.activateWindow()
@@ -3243,8 +3247,8 @@ class MainWindow(QMainWindow):
         if display_status == "Complete" or worker_status == "Complete" or (tot_bytes > 0 and comp_bytes >= tot_bytes) or pct_str == "Complete":
             display_status = "Complete"
             final_display = "Complete"
-        elif display_status == "Downloading":
-            final_display = pct_str if pct_str else "Downloading"
+        elif display_status in ["Downloading", "Resuming..."]:
+            final_display = pct_str if pct_str else display_status
         elif display_status in ["Paused", "Cancelled"]:
             pct_data = status_item.data(Qt.ItemDataRole.UserRole) if status_item else None
             final_display = pct_data if pct_data else display_status

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2840,13 +2840,21 @@ class MainWindow(QMainWindow):
                         status_item = self.download_table.item(row, 2)
                         logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
                         
-                        if logic_status in ["Paused", "Cancelled", "Error"]:
+                        worker = getattr(dialog, 'worker', dialog)
+                        if worker and (getattr(worker, 'is_paused', False) or getattr(worker, 'is_pause_requested', False) or logic_status in ["Paused", "Cancelled", "Error"]):
                             # Forward resume to existing worker
                             try:
-                                if hasattr(dialog, 'worker') and dialog.worker:
-                                    dialog.worker.resume()
+                                if hasattr(worker, 'resume'):
+                                    worker.resume()
                             except (RuntimeError, Exception):
                                 pass
+                            if hasattr(dialog, 'lbl_main_status'):
+                                try:
+                                    dialog.lbl_main_status.setText("Resuming...")
+                                    dialog.btn_pause.setText("Pause")
+                                    dialog.btn_cancel.setText("Cancel")
+                                except Exception:
+                                    pass
                             self._set_status_text(row, "Resuming...", logic_status="Resuming...")
                             if status_item:
                                 status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
@@ -2900,8 +2908,23 @@ class MainWindow(QMainWindow):
                     continue
                 key = self._get_item_key(item)
                 if key in self.active_downloads:
-                    dialog = self.active_downloads.pop(key, None)
-                    self._stop_worker_entry(dialog)
+                    dialog = self.active_downloads[key]
+                    worker = getattr(dialog, 'worker', dialog)
+                    if worker is not None and hasattr(worker, 'pause'):
+                        try:
+                            worker.pause()
+                        except Exception:
+                            pass
+                    
+                    if hasattr(dialog, 'lbl_main_status'):
+                        try:
+                            dialog.lbl_main_status.setText("Paused")
+                            dialog.btn_pause.setText("Resume")
+                            dialog.btn_cancel.setText("Close")
+                            dialog.lbl_speed.setText("0.00 B/s")
+                            dialog.lbl_time.setText("-")
+                        except Exception:
+                            pass
 
                     # Update status preserving percentage string
                     status_item = self.download_table.item(r, 2)
@@ -2926,10 +2949,6 @@ class MainWindow(QMainWindow):
                     item.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
                     self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
                     self._set_row_bold(r, False)
-
-                    # Close the dialog if it's a ProgressDialog
-                    if hasattr(dialog, 'reject'):
-                        dialog.reject()
         finally:
             self.download_table.blockSignals(False)
             if sorting_was_enabled:
@@ -3002,7 +3021,23 @@ class MainWindow(QMainWindow):
         self.download_table.blockSignals(True)
         try:
             for key, entry in list(self.active_downloads.items()):
-                self._stop_worker_entry(entry)
+                worker = getattr(entry, 'worker', entry)
+                if worker is not None and hasattr(worker, 'pause'):
+                    try:
+                        worker.pause()
+                    except Exception:
+                        pass
+                
+                if hasattr(entry, 'lbl_main_status'):
+                    try:
+                        entry.lbl_main_status.setText("Paused")
+                        entry.btn_pause.setText("Resume")
+                        entry.btn_cancel.setText("Close")
+                        entry.lbl_speed.setText("0.00 B/s")
+                        entry.lbl_time.setText("-")
+                    except Exception:
+                        pass
+
                 # Find the corresponding table item and update status/timestamp
                 for r in range(self.download_table.rowCount()):
                     item_ref = self.download_table.item(r, 0)
@@ -3028,7 +3063,6 @@ class MainWindow(QMainWindow):
                         self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
                         self._set_row_bold(r, False)
                         break
-            self.active_downloads.clear()
         finally:
             self.download_table.blockSignals(False)
             if sorting_was_enabled:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2817,57 +2817,69 @@ class MainWindow(QMainWindow):
         if not selected_items:
             return
         
-        rows = set(item.row() for item in selected_items)
-        for row in rows:
-            item_name = self.download_table.item(row, 0)
-            if not item_name:
-                continue
-            
-            # If already active, bring dialog to front or resume if paused
-            key = self._get_item_key(item_name)
-            if key in self.active_downloads:
-                dialog = self.active_downloads[key]
-                if not MemoryGuard.is_widget_alive(dialog) and not hasattr(dialog, 'isRunning'):
-                    self.active_downloads.pop(key, None)
-                    dialog = None
+        sorting_was_enabled = self.download_table.isSortingEnabled()
+        if sorting_was_enabled:
+            self.download_table.setSortingEnabled(False)
+        self.download_table.blockSignals(True)
+        try:
+            rows = set(item.row() for item in selected_items)
+            for row in rows:
+                item_name = self.download_table.item(row, 0)
+                if not item_name:
+                    continue
+                
+                # If already active, bring dialog to front or resume if paused
+                key = self._get_item_key(item_name)
+                if key in self.active_downloads:
+                    dialog = self.active_downloads[key]
+                    if not MemoryGuard.is_widget_alive(dialog) and not hasattr(dialog, 'isRunning'):
+                        self.active_downloads.pop(key, None)
+                        dialog = None
 
-                if dialog:
-                    status_item = self.download_table.item(row, 2)
-                    logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
-                    
-                    if logic_status in ["Paused", "Cancelled", "Error"]:
-                        # Forward resume to existing worker
+                    if dialog:
+                        status_item = self.download_table.item(row, 2)
+                        logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
+                        
+                        if logic_status in ["Paused", "Cancelled", "Error"]:
+                            # Forward resume to existing worker
+                            try:
+                                if hasattr(dialog, 'worker') and dialog.worker:
+                                    dialog.worker.resume()
+                            except (RuntimeError, Exception):
+                                pass
+                            self._set_status_text(row, "Resuming...", logic_status="Resuming...")
+                            if status_item:
+                                status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
+                            self._set_row_bold(row, True)
+                        
                         try:
-                            if hasattr(dialog, 'worker') and dialog.worker:
-                                dialog.worker.resume()
+                            dialog.activateWindow()
+                            dialog.raise_()
                         except (RuntimeError, Exception):
                             pass
-                        self._set_status_text(row, "Resuming...", logic_status="Resuming...")
-                        if status_item:
-                            status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
-                    
-                    try:
-                        dialog.activateWindow()
-                        dialog.raise_()
-                    except (RuntimeError, Exception):
-                        pass
-                    continue
-            
-            # Start/Resume download
-            url = item_name.data(Qt.ItemDataRole.UserRole)
-            filename = item_name.text()
-            
-            if url:
-                self._set_status_text(row, "Resuming...", logic_status="Resuming...")
-                status_item = self.download_table.item(row, 2)
-                if status_item:
-                    status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
-                # Update last try timestamp before resuming
-                new_timestamp = str(time.time())
-                item_name.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
-                self._set_timestamp_item(row, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
+                        continue
                 
-                self._start_download_worker(url, item_name, resume_filename=filename)
+                # Start/Resume download
+                url = item_name.data(Qt.ItemDataRole.UserRole)
+                filename = item_name.text()
+                
+                if url:
+                    self._set_status_text(row, "Resuming...", logic_status="Resuming...")
+                    status_item = self.download_table.item(row, 2)
+                    if status_item:
+                        status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
+                    # Update last try timestamp before resuming
+                    new_timestamp = str(time.time())
+                    item_name.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
+                    self._set_timestamp_item(row, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
+                    self._set_row_bold(row, True)
+                    
+                    self._start_download_worker(url, item_name, resume_filename=filename)
+        finally:
+            self.download_table.blockSignals(False)
+            if sorting_was_enabled:
+                self.download_table.setSortingEnabled(True)
+            self.download_table.viewport().update()
         
         self.update_ui_states()
 
@@ -2876,42 +2888,53 @@ class MainWindow(QMainWindow):
         if not selected_items:
             return
         
-        rows = set(item.row() for item in selected_items)
-        for r in rows:
-            item = self.download_table.item(r, 0)
-            if not item:
-                continue
-            key = self._get_item_key(item)
-            if key in self.active_downloads:
-                dialog = self.active_downloads.pop(key, None)
-                self._stop_worker_entry(dialog)
+        sorting_was_enabled = self.download_table.isSortingEnabled()
+        if sorting_was_enabled:
+            self.download_table.setSortingEnabled(False)
+        self.download_table.blockSignals(True)
+        try:
+            rows = set(item.row() for item in selected_items)
+            for r in rows:
+                item = self.download_table.item(r, 0)
+                if not item:
+                    continue
+                key = self._get_item_key(item)
+                if key in self.active_downloads:
+                    dialog = self.active_downloads.pop(key, None)
+                    self._stop_worker_entry(dialog)
 
-                # Update status preserving percentage string
-                status_item = self.download_table.item(r, 2)
-                if status_item:
-                    current_status = status_item.data(Qt.ItemDataRole.UserRole + 1)
-                    if current_status == "Complete" or status_item.text() == "Complete" or item.data(Qt.ItemDataRole.UserRole + 11) == "Complete":
-                        continue
-                if not status_item:
-                    status_item = QTableWidgetItem()
-                    self.download_table.setItem(r, 2, status_item)
-                status_item.setData(Qt.ItemDataRole.UserRole + 1, "Paused")
-                pct_data = status_item.data(Qt.ItemDataRole.UserRole)
-                final_display = pct_data if pct_data and "%" in str(pct_data) else "Paused"
-                self._set_status_text(r, final_display, logic_status="Paused")
+                    # Update status preserving percentage string
+                    status_item = self.download_table.item(r, 2)
+                    if status_item:
+                        current_status = status_item.data(Qt.ItemDataRole.UserRole + 1)
+                        if current_status == "Complete" or status_item.text() == "Complete" or item.data(Qt.ItemDataRole.UserRole + 11) == "Complete":
+                            continue
+                    if not status_item:
+                        status_item = QTableWidgetItem()
+                        self.download_table.setItem(r, 2, status_item)
+                    status_item.setData(Qt.ItemDataRole.UserRole + 1, "Paused")
+                    pct_data = status_item.data(Qt.ItemDataRole.UserRole)
+                    final_display = pct_data if pct_data and "%" in str(pct_data) else "Paused"
+                    self._set_status_text(r, final_display, logic_status="Paused")
 
-                # Reset Time Left and Rate on pause
-                self._set_sortable_item(r, 3, "", parse_time_to_sec)
-                self._set_sortable_item(r, 4, "", parse_size_to_bytes)
+                    # Reset Time Left and Rate on pause
+                    self._set_sortable_item(r, 3, "", parse_time_to_sec)
+                    self._set_sortable_item(r, 4, "", parse_size_to_bytes)
 
-                # Update last try timestamp on pause
-                new_timestamp = str(time.time())
-                item.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
-                self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
+                    # Update last try timestamp on pause
+                    new_timestamp = str(time.time())
+                    item.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
+                    self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
+                    self._set_row_bold(r, False)
 
-                # Close the dialog if it's a ProgressDialog
-                if hasattr(dialog, 'reject'):
-                    dialog.reject()
+                    # Close the dialog if it's a ProgressDialog
+                    if hasattr(dialog, 'reject'):
+                        dialog.reject()
+        finally:
+            self.download_table.blockSignals(False)
+            if sorting_was_enabled:
+                self.download_table.setSortingEnabled(True)
+            self.download_table.viewport().update()
         
         self.update_ui_states()
 
@@ -2973,33 +2996,44 @@ class MainWindow(QMainWindow):
             pass
 
     def stop_all_downloads(self):
-        for key, entry in list(self.active_downloads.items()):
-            self._stop_worker_entry(entry)
-            # Find the corresponding table item and update status/timestamp
-            for r in range(self.download_table.rowCount()):
-                item_ref = self.download_table.item(r, 0)
-                if item_ref and self._get_item_key(item_ref) == key:
-                    status_item = self.download_table.item(r, 2)
-                    if status_item:
-                        current_status = status_item.data(Qt.ItemDataRole.UserRole + 1)
-                        if current_status == "Complete" or status_item.text() == "Complete" or item_ref.data(Qt.ItemDataRole.UserRole + 11) == "Complete":
-                            continue
-                    if not status_item:
-                        status_item = QTableWidgetItem()
-                        self.download_table.setItem(r, 2, status_item)
-                    status_item.setData(Qt.ItemDataRole.UserRole + 1, "Paused")
-                    pct_data = status_item.data(Qt.ItemDataRole.UserRole)
-                    final_display = pct_data if pct_data and "%" in str(pct_data) else "Paused"
-                    self._set_status_text(r, final_display, logic_status="Paused")
+        sorting_was_enabled = self.download_table.isSortingEnabled()
+        if sorting_was_enabled:
+            self.download_table.setSortingEnabled(False)
+        self.download_table.blockSignals(True)
+        try:
+            for key, entry in list(self.active_downloads.items()):
+                self._stop_worker_entry(entry)
+                # Find the corresponding table item and update status/timestamp
+                for r in range(self.download_table.rowCount()):
+                    item_ref = self.download_table.item(r, 0)
+                    if item_ref and self._get_item_key(item_ref) == key:
+                        status_item = self.download_table.item(r, 2)
+                        if status_item:
+                            current_status = status_item.data(Qt.ItemDataRole.UserRole + 1)
+                            if current_status == "Complete" or status_item.text() == "Complete" or item_ref.data(Qt.ItemDataRole.UserRole + 11) == "Complete":
+                                continue
+                        if not status_item:
+                            status_item = QTableWidgetItem()
+                            self.download_table.setItem(r, 2, status_item)
+                        status_item.setData(Qt.ItemDataRole.UserRole + 1, "Paused")
+                        pct_data = status_item.data(Qt.ItemDataRole.UserRole)
+                        final_display = pct_data if pct_data and "%" in str(pct_data) else "Paused"
+                        self._set_status_text(r, final_display, logic_status="Paused")
 
-                    self._set_sortable_item(r, 3, "", parse_time_to_sec)
-                    self._set_sortable_item(r, 4, "", parse_size_to_bytes)
+                        self._set_sortable_item(r, 3, "", parse_time_to_sec)
+                        self._set_sortable_item(r, 4, "", parse_size_to_bytes)
 
-                    new_timestamp = str(time.time())
-                    item_ref.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
-                    self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
-                    break
-        self.active_downloads.clear()
+                        new_timestamp = str(time.time())
+                        item_ref.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
+                        self._set_timestamp_item(r, 5, format_timestamp_relative(new_timestamp, max_relative_seconds=300))
+                        self._set_row_bold(r, False)
+                        break
+            self.active_downloads.clear()
+        finally:
+            self.download_table.blockSignals(False)
+            if sorting_was_enabled:
+                self.download_table.setSortingEnabled(True)
+            self.download_table.viewport().update()
         if hasattr(self, "active_speeds"):
             self.active_speeds.clear()
         self.update_status_bar_speed()
@@ -3327,49 +3361,62 @@ class MainWindow(QMainWindow):
         else:
             display_status = "Error"
 
+        sorting_was_enabled = self.download_table.isSortingEnabled()
+        if sorting_was_enabled:
+            self.download_table.setSortingEnabled(False)
+        self.download_table.blockSignals(True)
         try:
             row = self.download_table.row(item_ref)
         except RuntimeError:
+            self.download_table.blockSignals(False)
+            if sorting_was_enabled:
+                self.download_table.setSortingEnabled(True)
             return 
             
-        if row != -1:
-            status_item = self.download_table.item(row, 2)
-            if not status_item:
-                self._set_status_text(row, "")
+        try:
+            if row != -1:
                 status_item = self.download_table.item(row, 2)
-            
-            # Formatting final display text and updating logical status
-            status_item.setData(Qt.ItemDataRole.UserRole + 1, display_status)
-            
-            if display_status == "Complete":
-                final_display = "Complete"
-                status_item.setData(Qt.ItemDataRole.UserRole, "Complete")
-                path = item_ref.data(Qt.ItemDataRole.UserRole + 1)
-                if path and os.path.exists(path) and os.path.isfile(path):
-                    try:
-                        actual_sz = os.path.getsize(path)
-                        if actual_sz > 0:
-                            self._set_sortable_item(row, 1, format_bytes(actual_sz), parse_size_to_bytes)
-                    except Exception:
-                        pass
-            elif display_status in ["Paused", "Cancelled"]:
-                pct = status_item.data(Qt.ItemDataRole.UserRole)
-                final_display = pct if pct else "0.00%"
-            else:
-                final_display = display_status
-            
-            self._set_status_text(row, final_display, logic_status=display_status)
-            
-            if display_status in ["Complete", "Error"]:
-                 self._set_sortable_item(row, 3, "", parse_time_to_sec)
-                 self._set_sortable_item(row, 4, "", parse_size_to_bytes)
-            elif display_status in ["Paused", "Cancelled"]:
-                 self._set_sortable_item(row, 4, "", parse_size_to_bytes)
+                if not status_item:
+                    self._set_status_text(row, "")
+                    status_item = self.download_table.item(row, 2)
+                
+                # Formatting final display text and updating logical status
+                status_item.setData(Qt.ItemDataRole.UserRole + 1, display_status)
+                
+                if display_status == "Complete":
+                    final_display = "Complete"
+                    status_item.setData(Qt.ItemDataRole.UserRole, "Complete")
+                    path = item_ref.data(Qt.ItemDataRole.UserRole + 1)
+                    if path and os.path.exists(path) and os.path.isfile(path):
+                        try:
+                            actual_sz = os.path.getsize(path)
+                            if actual_sz > 0:
+                                self._set_sortable_item(row, 1, format_bytes(actual_sz), parse_size_to_bytes)
+                        except Exception:
+                            pass
+                elif display_status in ["Paused", "Cancelled"]:
+                    pct = status_item.data(Qt.ItemDataRole.UserRole)
+                    final_display = pct if pct else "0.00%"
+                else:
+                    final_display = display_status
+                
+                self._set_status_text(row, final_display, logic_status=display_status)
+                
+                if display_status in ["Complete", "Error"]:
+                     self._set_sortable_item(row, 3, "", parse_time_to_sec)
+                     self._set_sortable_item(row, 4, "", parse_size_to_bytes)
+                elif display_status in ["Paused", "Cancelled"]:
+                     self._set_sortable_item(row, 4, "", parse_size_to_bytes)
 
-            final_timestamp = str(time.time())
-            item_ref.setData(Qt.ItemDataRole.UserRole + 2, final_timestamp)
-            self._set_timestamp_item(row, 5, format_timestamp_relative(final_timestamp, max_relative_seconds=300))
-            self._set_row_bold(row, False)
+                final_timestamp = str(time.time())
+                item_ref.setData(Qt.ItemDataRole.UserRole + 2, final_timestamp)
+                self._set_timestamp_item(row, 5, format_timestamp_relative(final_timestamp, max_relative_seconds=300))
+                self._set_row_bold(row, False)
+        finally:
+            self.download_table.blockSignals(False)
+            if sorting_was_enabled:
+                self.download_table.setSortingEnabled(True)
+            self.download_table.viewport().update()
 
         # Handle UI Popups / Dialogs
         if key in self.active_downloads:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1739,6 +1739,7 @@ class MainWindow(QMainWindow):
             return
         if row < 0 or row >= self.download_table.rowCount():
             return
+        changed = False
         for col in range(self.download_table.columnCount()):
             item = self.download_table.item(row, col)
             if item:
@@ -1747,6 +1748,12 @@ class MainWindow(QMainWindow):
                     font.setBold(is_bold)
                     font.setFeature(QFont.Tag.fromString('tnum'), 1)
                     item.setFont(font)
+                    changed = True
+        if changed and hasattr(self, "download_table"):
+            row_top = self.download_table.rowViewportPosition(row)
+            row_height = self.download_table.rowHeight(row)
+            if row_height > 0:
+                self.download_table.viewport().update(0, row_top, self.download_table.viewport().width(), row_height)
 
     def _set_sortable_item(self, row, col, text, parser_func):
         item = self.download_table.item(row, col)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2786,6 +2786,12 @@ class MainWindow(QMainWindow):
             worker = Aria2Worker(url, item_ref.row(), save_dir, resume_filename, user_agent=user_agent, cookies=cookies, temp_dir=temp_dir)
         else:
             worker = DownloadWorker(url, item_ref.row(), save_dir, resume_filename, user_agent=user_agent, cookies=cookies, temp_dir=temp_dir)
+        
+        gen = (item_ref.data(Qt.ItemDataRole.UserRole + 13) or 0) + 1
+        item_ref.setData(Qt.ItemDataRole.UserRole + 13, gen)
+        item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Normal")
+        worker.generation = gen
+
         item_ref.setData(Qt.ItemDataRole.UserRole + 1, worker.target_path)
         item_ref.setText(worker.filename)
         item_ref.setToolTip(worker.filename)
@@ -2842,6 +2848,10 @@ class MainWindow(QMainWindow):
                         
                         worker = getattr(dialog, 'worker', dialog)
                         if worker and (getattr(worker, 'is_paused', False) or getattr(worker, 'is_pause_requested', False) or logic_status in ["Paused", "Cancelled", "Error"]):
+                            gen = (item_name.data(Qt.ItemDataRole.UserRole + 13) or 0) + 1
+                            item_name.setData(Qt.ItemDataRole.UserRole + 13, gen)
+                            item_name.setData(Qt.ItemDataRole.UserRole + 11, "Normal")
+                            worker.generation = gen
                             # Forward resume to existing worker
                             try:
                                 if hasattr(worker, 'resume'):
@@ -2906,6 +2916,7 @@ class MainWindow(QMainWindow):
                 item = self.download_table.item(r, 0)
                 if not item:
                     continue
+                item.setData(Qt.ItemDataRole.UserRole + 11, "Paused")
                 key = self._get_item_key(item)
                 if key in self.active_downloads:
                     dialog = self.active_downloads[key]
@@ -2930,7 +2941,7 @@ class MainWindow(QMainWindow):
                     status_item = self.download_table.item(r, 2)
                     if status_item:
                         current_status = status_item.data(Qt.ItemDataRole.UserRole + 1)
-                        if current_status == "Complete" or status_item.text() == "Complete" or item.data(Qt.ItemDataRole.UserRole + 11) == "Complete":
+                        if current_status == "Complete" or status_item.text() == "Complete":
                             continue
                     if not status_item:
                         status_item = QTableWidgetItem()
@@ -2956,6 +2967,167 @@ class MainWindow(QMainWindow):
             self.download_table.viewport().update()
         
         self.update_ui_states()
+
+    def _get_display_state(self, item_ref, worker_status, comp_bytes=0, tot_bytes=0):
+        """
+        Central IDM-style State Resolver.
+        User Intent State (item_ref UserRole+11) is the supreme authority.
+        Engine State (worker_status) is only considered when User Intent is Normal/Active.
+        """
+        user_state = item_ref.data(Qt.ItemDataRole.UserRole + 11) # "Complete", "Paused", "Cancelled", "Normal"
+        row = self.download_table.row(item_ref) if hasattr(self, "download_table") else -1
+        status_item = self.download_table.item(row, 2) if (row >= 0 and hasattr(self, "download_table")) else None
+        prev_pct_str = status_item.data(Qt.ItemDataRole.UserRole) if status_item else None
+        
+        # Calculate percentage string
+        pct_str = ""
+        if tot_bytes > 0:
+            pct_val = min(100.0, (comp_bytes / tot_bytes) * 100.0)
+            if prev_pct_str and "%" in str(prev_pct_str) and pct_val == 0.0:
+                try:
+                    prev_val = float(str(prev_pct_str).replace("%", "").strip())
+                    if prev_val > 0:
+                        pct_val = prev_val
+                except ValueError:
+                    pass
+            pct_str = f"{pct_val:.2f}%"
+        elif prev_pct_str and "%" in str(prev_pct_str):
+            pct_str = str(prev_pct_str)
+
+        # 1. User Intent: Complete
+        if user_state == "Complete" or worker_status == "Complete" or (tot_bytes > 0 and comp_bytes >= tot_bytes):
+            item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Complete")
+            return "Complete", "Complete", pct_str or "100.00%", False
+
+        # 2. User Intent: Paused
+        if user_state == "Paused":
+            final_display = pct_str if pct_str else "Paused"
+            return final_display, "Paused", pct_str, False
+
+        # 3. User Intent: Cancelled
+        if user_state == "Cancelled":
+            final_display = pct_str if pct_str else "Cancelled"
+            return final_display, "Cancelled", pct_str, False
+
+        # 4. User Intent: Normal / Active -> Interpret Engine Status
+        if worker_status.startswith("Receiving data") or worker_status.startswith("Downloading"):
+            engine_status = "Downloading"
+            final_display = pct_str if pct_str else "Downloading"
+            is_active = True
+        elif worker_status in ["Resuming...", "Resume GET..."]:
+            engine_status = "Resuming..."
+            final_display = pct_str if pct_str else "Resuming..."
+            is_active = True
+        elif worker_status == "Connecting...":
+            engine_status = "Connecting..."
+            final_display = pct_str if pct_str else "Connecting..."
+            is_active = True
+        elif worker_status in ["Paused", "Cancelled"]:
+            # Engine reports paused while user state is Normal -> transitioning
+            engine_status = "Resuming..."
+            final_display = pct_str if pct_str else "Resuming..."
+            is_active = True
+        elif worker_status == "Error":
+            engine_status = "Error"
+            final_display = "Error"
+            is_active = False
+        else:
+            engine_status = worker_status if worker_status else "Downloading"
+            final_display = pct_str if pct_str else engine_status
+            is_active = True
+
+        return final_display, engine_status, pct_str, is_active
+
+    def _apply_download_row_data(self, item_ref, data):
+        try:
+            row = self.download_table.row(item_ref)
+        except RuntimeError:
+            return # object has been deleted by remove
+        if row == -1: return 
+
+        # Freshness guard: Discard stale callbacks from older sessions
+        if len(data) > 8 and data[8] is not None:
+            callback_gen = data[8]
+            current_gen = item_ref.data(Qt.ItemDataRole.UserRole + 13)
+            if current_gen is not None and callback_gen < current_gen:
+                return
+
+        status_item = self.download_table.item(row, 2)
+        old_status = status_item.text() if status_item else ""
+        old_logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
+
+        # --- PROTECTION GUARD ---
+        # If the row is already marked as Complete, ignore any late progress signals unless actively downloading (e.g. redownload)
+        key = self._get_item_key(item_ref)
+        if item_ref.data(Qt.ItemDataRole.UserRole + 11) == "Complete" and key not in getattr(self, "active_downloads", {}):
+            return
+        
+        # --- Update Last Try Timestamp ---
+        new_timestamp = str(time.time())
+        item_ref.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
+
+        new_name = data[0]
+        if item_ref.text() != new_name:
+            item_ref.setText(new_name)
+            item_ref.setToolTip(new_name)
+            item_ref.setIcon(get_file_icon(new_name))
+        
+        # Col 1: Size (Display total file size if known)
+        tot_bytes = data[6] if len(data) > 6 else 0
+        comp_bytes = data[5] if len(data) > 5 else 0
+
+        if tot_bytes > 0:
+            size_display = format_bytes(tot_bytes)
+        elif comp_bytes > 0:
+            size_display = format_bytes(comp_bytes)
+        else:
+            size_display = data[1] if len(data) > 1 and data[1] else "Unknown"
+
+        self._set_sortable_item(row, 1, size_display, parse_size_to_bytes)
+        
+        # Col 2: Status (Resolved centrally via IDM State Architecture)
+        worker_status = data[2] if len(data) > 2 else ""
+        final_display, display_status, pct_str, is_active = self._get_display_state(item_ref, worker_status, comp_bytes, tot_bytes)
+
+        if pct_str and pct_str != "Complete" and status_item:
+            status_item.setData(Qt.ItemDataRole.UserRole, pct_str)
+        
+        if final_display != old_status or display_status != old_logic_status:
+            self._set_status_text(row, final_display, logic_status=display_status)
+            status_item = self.download_table.item(row, 2)
+            if status_item:
+                status_item.setData(Qt.ItemDataRole.UserRole + 1, display_status)
+            if display_status != old_logic_status:
+                self.update_ui_states()
+        
+        # Col 3 & 4: Time Left & Rate
+        if display_status in ["Complete", "Error", "Paused", "Cancelled", "Queued"]:
+            self._set_sortable_item(row, 3, "", parse_time_to_sec)
+            self._set_sortable_item(row, 4, "", parse_size_to_bytes)
+            if hasattr(self, "active_speeds"):
+                self.active_speeds.pop(key, None)
+        else:
+            time_val = data[3] if len(data) > 3 else ""
+            rate_val = data[4] if len(data) > 4 else ""
+            self._set_sortable_item(row, 3, time_val, parse_time_to_sec)
+            self._set_sortable_item(row, 4, rate_val, parse_size_to_bytes)
+            if hasattr(self, "active_speeds"):
+                raw_speed = data[7] if len(data) > 7 and isinstance(data[7], (int, float)) else None
+                if raw_speed is not None:
+                    self.active_speeds[key] = float(raw_speed)
+                elif rate_val:
+                    self.active_speeds[key] = parse_size_to_bytes(str(rate_val).replace("/s", "").strip())
+        self.update_status_bar_speed()
+        
+        # Col 5: Last Try
+        formatted_last_try = format_timestamp_relative(new_timestamp, max_relative_seconds=300)
+        last_try_item = self.download_table.item(row, 5)
+        if not last_try_item:
+            self._set_timestamp_item(row, 5, formatted_last_try)
+        elif last_try_item.text() != formatted_last_try:
+            last_try_item.setText(formatted_last_try)
+        
+        self._set_row_bold(row, is_active)
 
     def _stop_worker_entry(self, entry):
         """Stop either a ProgressDialog (has .worker) or a bare YtDlpDownloadWorker thread."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -824,7 +824,6 @@ class MainWindow(QMainWindow):
             QTableWidget::item:focus { 
                 border: none; 
                 outline: 0; 
-                background: transparent; 
             }
             QHeaderView::section {
                 font-weight: normal;
@@ -1753,6 +1752,9 @@ class MainWindow(QMainWindow):
         created = False
         if not item:
             item = SortableTableWidgetItem(text)
+            font = QFont(QApplication.font())
+            font.setFeature(QFont.Tag.fromString('tnum'), 1)
+            item.setFont(font)
             self.download_table.setItem(row, col, item)
             created = True
         elif item.text() != text:
@@ -1762,13 +1764,6 @@ class MainWindow(QMainWindow):
         col_names = {1: "Size", 3: "Time Left", 4: "Transfer Rate"}
         if col in col_names:
             item.setToolTip(f"{col_names[col]}: {text}" if text else f"{col_names[col]}: N/A")
-
-        if getattr(self, "table_style", "classic") != "modern":
-            is_active = self._is_row_active(row)
-            font = QFont(QApplication.font())
-            font.setFeature(QFont.Tag.fromString('tnum'), 1)
-            font.setBold(is_active)
-            item.setFont(font)
             
         raw_val = parser_func(text)
         if item.data(Qt.ItemDataRole.UserRole) != raw_val:
@@ -1779,6 +1774,9 @@ class MainWindow(QMainWindow):
         created = False
         if not item:
             item = QTableWidgetItem(text)
+            font = QFont(QApplication.font())
+            font.setFeature(QFont.Tag.fromString('tnum'), 1)
+            item.setFont(font)
             self.download_table.setItem(row, 2, item)
             created = True
         elif item.text() != text:
@@ -1790,30 +1788,19 @@ class MainWindow(QMainWindow):
         elif text in ["Paused", "Complete", "Finished", "Error", "Cancelled", "Connecting...", "Downloading", "Resuming...", "Pending...", "Queued"]:
             item.setData(Qt.ItemDataRole.UserRole + 1, text)
 
-        if getattr(self, "table_style", "classic") != "modern":
-            is_active = self._is_row_active(row) or text in ["Connecting...", "Downloading", "Resuming...", "Pending...", "Receiving data..."]
-            font = QFont(QApplication.font())
-            font.setFeature(QFont.Tag.fromString('tnum'), 1)
-            font.setBold(is_active)
-            item.setFont(font)
-
     def _set_timestamp_item(self, row, col, text):
         item = self.download_table.item(row, col)
         if not item:
             item = QTableWidgetItem(text)
+            font = QFont(QApplication.font())
+            font.setFeature(QFont.Tag.fromString('tnum'), 1)
+            item.setFont(font)
             self.download_table.setItem(row, col, item)
         elif item.text() != text:
             item.setText(text)
             
         col_name = "Last Attempt" if col == 5 else "Date Added"
         item.setToolTip(f"{col_name}: {text}" if text else f"{col_name}: N/A")
-
-        if getattr(self, "table_style", "classic") != "modern":
-            is_active = self._is_row_active(row)
-            font = QFont(QApplication.font())
-            font.setFeature(QFont.Tag.fromString('tnum'), 1)
-            font.setBold(is_active)
-            item.setFont(font)
         return item
 
     def add_new_download(self, url, category="General", save_path=""):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2999,17 +2999,24 @@ class MainWindow(QMainWindow):
             item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Complete")
             return "Complete", "Complete", pct_str or "100.00%", False
 
-        # 2. User Intent: Paused
-        if user_state == "Paused":
+        # 2. Worker reports active/resuming states -> sync user intent to Normal
+        if worker_status.startswith("Receiving data") or worker_status.startswith("Downloading") or worker_status in ["Resuming...", "Resume GET...", "Connecting..."]:
+            item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Normal")
+            user_state = "Normal"
+
+        # 3. User Intent / Progress Dialog Paused
+        if user_state == "Paused" or worker_status == "Paused":
+            item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Paused")
             final_display = pct_str if pct_str else "Paused"
             return final_display, "Paused", pct_str, False
 
-        # 3. User Intent: Cancelled
-        if user_state == "Cancelled":
+        # 4. User Intent: Cancelled
+        if user_state == "Cancelled" or worker_status == "Cancelled":
+            item_ref.setData(Qt.ItemDataRole.UserRole + 11, "Cancelled")
             final_display = pct_str if pct_str else "Cancelled"
             return final_display, "Cancelled", pct_str, False
 
-        # 4. User Intent: Normal / Active -> Interpret Engine Status
+        # 5. User Intent: Normal / Active -> Interpret Engine Status
         if worker_status.startswith("Receiving data") or worker_status.startswith("Downloading"):
             engine_status = "Downloading"
             final_display = pct_str if pct_str else "Downloading"
@@ -3021,11 +3028,6 @@ class MainWindow(QMainWindow):
         elif worker_status == "Connecting...":
             engine_status = "Connecting..."
             final_display = pct_str if pct_str else "Connecting..."
-            is_active = True
-        elif worker_status in ["Paused", "Cancelled"]:
-            # Engine reports paused while user state is Normal -> transitioning
-            engine_status = "Resuming..."
-            final_display = pct_str if pct_str else "Resuming..."
             is_active = True
         elif worker_status == "Error":
             engine_status = "Error"
@@ -3417,132 +3419,6 @@ class MainWindow(QMainWindow):
             if sorting_was_enabled:
                 self.download_table.setSortingEnabled(True)
             self._notify_views_changed()
-
-    def _apply_download_row_data(self, item_ref, data):
-        try:
-            row = self.download_table.row(item_ref)
-        except RuntimeError:
-            return # object has been deleted by remove
-        if row == -1: return 
-
-        status_item = self.download_table.item(row, 2)
-        old_status = status_item.text() if status_item else ""
-        old_logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
-
-        # --- PROTECTION GUARD ---
-        # If the row is already marked as Complete, ignore any late progress signals unless actively downloading (e.g. redownload)
-        key = self._get_item_key(item_ref)
-        if old_logic_status == "Complete" and key not in getattr(self, "active_downloads", {}):
-            return
-        
-        # --- Update Last Try Timestamp ---
-        new_timestamp = str(time.time())
-        item_ref.setData(Qt.ItemDataRole.UserRole + 2, new_timestamp)
-
-        new_name = data[0]
-        if item_ref.text() != new_name:
-            item_ref.setText(new_name)
-            item_ref.setToolTip(new_name)
-            item_ref.setIcon(get_file_icon(new_name))
-        
-        # Col 1: Size (Display total file size if known)
-        tot_bytes = data[6] if len(data) > 6 else 0
-        comp_bytes = data[5] if len(data) > 5 else 0
-
-        if tot_bytes > 0:
-            size_display = format_bytes(tot_bytes)
-        elif comp_bytes > 0:
-            size_display = format_bytes(comp_bytes)
-        else:
-            size_display = data[1] if len(data) > 1 and data[1] else "Unknown"
-
-        self._set_sortable_item(row, 1, size_display, parse_size_to_bytes)
-        
-        # Col 2: Status
-        worker_status = data[2] if len(data) > 2 else ""
-        if worker_status.startswith("Receiving data") or worker_status.startswith("Downloading"):
-            display_status = "Downloading"
-        elif worker_status == "Connecting...":
-            display_status = "Connecting..."
-        elif worker_status == "Complete":
-            display_status = "Complete"
-        elif worker_status == "Resume GET...":
-            display_status = "Resuming..."
-        elif worker_status == "Queued":
-            display_status = "Queued"
-        else:
-            display_status = worker_status if worker_status else old_logic_status
-
-        # If data[5] and data[6] are valid integers, calculate actual %
-        pct_str = ""
-        if len(data) > 6 and isinstance(data[5], (int, float)) and isinstance(data[6], (int, float)):
-            comp = data[5]
-            tot = data[6]
-            if tot > 0:
-                pct_val = min(100.0, (comp / tot) * 100.0)
-                # If progress reports 0% (e.g. initial connection), do not overwrite higher previous percentage
-                prev_pct_str = status_item.data(Qt.ItemDataRole.UserRole) if status_item else None
-                if prev_pct_str and "%" in str(prev_pct_str) and pct_val == 0.0:
-                    try:
-                        prev_val = float(str(prev_pct_str).replace("%", "").strip())
-                        if prev_val > 0:
-                            pct_val = prev_val
-                    except ValueError:
-                        pass
-                pct_str = f"{pct_val:.2f}%"
-
-        if display_status == "Complete" or worker_status == "Complete" or (tot_bytes > 0 and comp_bytes >= tot_bytes) or pct_str == "Complete":
-            display_status = "Complete"
-            final_display = "Complete"
-        elif display_status in ["Downloading", "Resuming..."]:
-            final_display = pct_str if pct_str else display_status
-        elif display_status in ["Paused", "Cancelled"]:
-            pct_data = status_item.data(Qt.ItemDataRole.UserRole) if status_item else None
-            final_display = pct_data if pct_data else display_status
-        else:
-            final_display = display_status
-
-        if pct_str and pct_str != "Complete" and status_item:
-            status_item.setData(Qt.ItemDataRole.UserRole, pct_str)
-        
-        if final_display != old_status or display_status != old_logic_status:
-            self._set_status_text(row, final_display, logic_status=display_status)
-            status_item = self.download_table.item(row, 2)
-            if status_item:
-                status_item.setData(Qt.ItemDataRole.UserRole + 1, display_status)
-            if display_status != old_logic_status:
-                self.update_ui_states()
-        
-        # Col 3 & 4: Time Left & Rate
-        if display_status in ["Complete", "Error", "Paused", "Cancelled", "Queued"]:
-            self._set_sortable_item(row, 3, "", parse_time_to_sec)
-            self._set_sortable_item(row, 4, "", parse_size_to_bytes)
-            if hasattr(self, "active_speeds"):
-                self.active_speeds.pop(key, None)
-        else:
-            time_val = data[3] if len(data) > 3 else ""
-            rate_val = data[4] if len(data) > 4 else ""
-            self._set_sortable_item(row, 3, time_val, parse_time_to_sec)
-            self._set_sortable_item(row, 4, rate_val, parse_size_to_bytes)
-            if hasattr(self, "active_speeds"):
-                raw_speed = data[7] if len(data) > 7 and isinstance(data[7], (int, float)) else None
-                if raw_speed is not None:
-                    self.active_speeds[key] = float(raw_speed)
-                elif rate_val:
-                    self.active_speeds[key] = parse_size_to_bytes(str(rate_val).replace("/s", "").strip())
-        self.update_status_bar_speed()
-        
-        # Col 5: Last Try
-        formatted_last_try = format_timestamp_relative(new_timestamp, max_relative_seconds=300)
-        last_try_item = self.download_table.item(row, 5)
-        if not last_try_item:
-            self._set_timestamp_item(row, 5, formatted_last_try)
-        elif last_try_item.text() != formatted_last_try:
-            last_try_item.setText(formatted_last_try)
-        
-        is_active = (display_status not in ["Complete", "Error", "Paused", "Cancelled", "Queued"])
-        self._set_row_bold(row, is_active)
-
     def download_finished(self, item_ref, status_text):
         key = self._get_item_key(item_ref)
         if hasattr(self, "active_speeds"):

--- a/src/ui/qml/DownloadCard.qml
+++ b/src/ui/qml/DownloadCard.qml
@@ -22,7 +22,6 @@ Kirigami.Card {
                 id: fileNameLabel
                 text: model.filename || "File"
                 font.bold: true
-                font.weight: Font.DemiBold
                 elide: Text.ElideRight
                 Layout.fillWidth: true
 
@@ -41,6 +40,7 @@ Kirigami.Card {
                 font.features: { "tnum": 1 }
                 color: model.status === "Complete" ? Kirigami.Theme.positiveTextColor :
                        model.status === "Error" ? Kirigami.Theme.negativeTextColor :
+                       (model.status === "Paused" || model.status === "Cancelled") ? Kirigami.Theme.neutralTextColor :
                        Kirigami.Theme.highlightColor
             }
         }

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -113,10 +113,13 @@ Kirigami.ApplicationWindow {
     }
 
     function updateFilteredModel() {
-        filteredModel.clear()
         var items = downloadBridge.downloads
-        if (!items) return
+        if (!items) {
+            filteredModel.clear()
+            return
+        }
 
+        var matching = []
         for (var i = 0; i < items.length; i++) {
             var item = items[i]
             var name = (item.filename || "").toLowerCase()
@@ -137,7 +140,18 @@ Kirigami.ApplicationWindow {
 
             if (matchSearch && matchCategory && matchStatus) {
                 item.originalIndex = i
-                filteredModel.append(item)
+                matching.push(item)
+            }
+        }
+
+        if (filteredModel.count === matching.length) {
+            for (var j = 0; j < matching.length; j++) {
+                filteredModel.set(j, matching[j])
+            }
+        } else {
+            filteredModel.clear()
+            for (var k = 0; k < matching.length; k++) {
+                filteredModel.append(matching[k])
             }
         }
     }

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1481,10 +1481,11 @@ def test_download_progress_dialog_respects_custom_connections(qapp, monkeypatch,
     assert len(progress_dlg.segment_bars) == 10
     assert progress_dlg.seg_table.rowCount() == 10
 
-    # Expand details and verify geometry
+    # Expand details and verify geometry is capped to 8 rows
     progress_dlg.toggle_details(True)
     assert not progress_dlg.details_frame.isHidden()
     assert progress_dlg.btn_details.text() == "Details <<"
+    expanded_height_10 = progress_dlg.height()
 
     # Collapse details
     progress_dlg.toggle_details(False)
@@ -1493,6 +1494,17 @@ def test_download_progress_dialog_respects_custom_connections(qapp, monkeypatch,
 
     progress_dlg.close()
     worker.deleteLater()
+
+    # Test with 16 connections — expanded height must remain identical to 8-row height
+    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 16})
+    worker16 = DownloadWorker("http://example.com/test.iso", 0, "/tmp")
+    progress_dlg16 = DownloadProgressDialog(worker16, None)
+    progress_dlg16.show()
+    assert progress_dlg16.seg_table.rowCount() == 16
+    progress_dlg16.toggle_details(True)
+    assert progress_dlg16.height() == expanded_height_10
+    progress_dlg16.close()
+    worker16.deleteLater()
 
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1495,16 +1495,19 @@ def test_download_progress_dialog_respects_custom_connections(qapp, monkeypatch,
     progress_dlg.close()
     worker.deleteLater()
 
-    # Test with 16 connections — expanded height must remain identical to 8-row height
-    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 16})
-    worker16 = DownloadWorker("http://example.com/test.iso", 0, "/tmp")
-    progress_dlg16 = DownloadProgressDialog(worker16, None)
-    progress_dlg16.show()
-    assert progress_dlg16.seg_table.rowCount() == 16
-    progress_dlg16.toggle_details(True)
-    assert progress_dlg16.height() == expanded_height_10
-    progress_dlg16.close()
-    worker16.deleteLater()
+    # Test with 1 connection — must render minimum 8 rows (1 active, 7 unused) and identical expanded height
+    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 1})
+    worker1 = DownloadWorker("http://example.com/test.iso", 0, "/tmp")
+    progress_dlg1 = DownloadProgressDialog(worker1, None)
+    progress_dlg1.show()
+    assert progress_dlg1.seg_table.rowCount() == 8
+    assert len(progress_dlg1.segment_bars) == 8
+    assert progress_dlg1.seg_table.item(0, 3).text() == "Pending..."
+    assert progress_dlg1.seg_table.item(1, 3).text() == "Unused"
+    progress_dlg1.toggle_details(True)
+    assert progress_dlg1.height() == expanded_height_10
+    progress_dlg1.close()
+    worker1.deleteLater()
 
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1466,6 +1466,36 @@ def test_options_dialog_max_connections_persistence(qapp, monkeypatch, tmp_path)
     dlg2.reject()
 
 
+def test_download_progress_dialog_respects_custom_connections(qapp, monkeypatch, tmp_path):
+    from ui.dialogs import DownloadProgressDialog
+    from core.workers import DownloadWorker
+    from core.utils import save_extension_config
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 10})
+
+    worker = DownloadWorker("http://example.com/test.iso", 0, "/tmp")
+    progress_dlg = DownloadProgressDialog(worker, None)
+    progress_dlg.show()
+
+    assert len(progress_dlg.segment_bars) == 10
+    assert progress_dlg.seg_table.rowCount() == 10
+
+    # Expand details and verify geometry
+    progress_dlg.toggle_details(True)
+    assert not progress_dlg.details_frame.isHidden()
+    assert progress_dlg.btn_details.text() == "Details <<"
+
+    # Collapse details
+    progress_dlg.toggle_details(False)
+    assert progress_dlg.details_frame.isHidden()
+    assert progress_dlg.btn_details.text() == "Details >>"
+
+    progress_dlg.close()
+    worker.deleteLater()
+
+
+
 
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1439,6 +1439,34 @@ def test_media_download_complete_dialog_shown(qapp, tmp_path):
     window.close()
 
 
+def test_options_dialog_max_connections_persistence(qapp, monkeypatch, tmp_path):
+    from ui.dialogs import OptionsDialog
+    from core.utils import save_extension_config, load_extension_config
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 8})
+
+    dlg = OptionsDialog()
+    assert hasattr(dlg, "spin_max_conn")
+    assert dlg.spin_max_conn.minimum() == 1
+    assert dlg.spin_max_conn.maximum() == 32
+    assert dlg.spin_max_conn.value() == 8
+
+    # Change to 16 and save
+    dlg.spin_max_conn.setValue(16)
+    dlg.save_and_accept()
+
+    loaded = load_extension_config()
+    assert loaded["max_connections"] == 16
+
+    # Reopen dialog and verify 16 is displayed
+    dlg2 = OptionsDialog()
+    assert dlg2.spin_max_conn.value() == 16
+    dlg2.reject()
+
+
+
 
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1510,6 +1510,162 @@ def test_download_progress_dialog_respects_custom_connections(qapp, monkeypatch,
     worker1.deleteLater()
 
 
+def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
+    """
+    Test multiple pause and resume operations on a single download across:
+    1. Toolbar Pause / Resume (action_stop, action_resume)
+    2. Download Window Pause / Resume (DownloadProgressDialog.toggle_pause)
+    3. Right-Click Context Menu (stop_selected_download, resume_selected_download)
+    4. Mixed cross-interface alternating cycles
+    """
+    window = MainWindow(start_ipc=False)
+    window.hide()
+
+    # Prevent spawning real background processes
+    monkeypatch.setattr(window, "_start_download_worker", lambda url, item_ref, resume_filename=None, **kw: None)
+
+    window.start_download(
+        url="http://example.com/test_lifecycle.iso",
+        custom_save_dir="/tmp",
+        start_paused=False,
+        show_dialog=False
+    )
+
+    row = 0
+    item0 = window.download_table.item(row, 0)
+    key = window._get_item_key(item0)
+    assert key is not None
+    item0.setData(Qt.ItemDataRole.UserRole + 13, 1)
+
+    from PyQt6.QtCore import QObject, pyqtSignal
+    class MockWorker(QObject):
+        log_signal = pyqtSignal(str)
+        main_bar_signal = pyqtSignal(object, object)
+        main_progress_signal = pyqtSignal(int, tuple)
+        finished_signal = pyqtSignal(int, str)
+        init_segments_signal = pyqtSignal(int)
+        segment_update_signal = pyqtSignal(int, object, object, float, str)
+
+        def __init__(self):
+            super().__init__()
+            self.is_paused = False
+            self.is_pause_requested = False
+            self.url = "http://example.com/test_lifecycle.iso"
+            self.target_path = "/tmp/test_lifecycle.iso"
+            self.filename = "test_lifecycle.iso"
+            self.row_index = 0
+            self.total_bytes = 1000000
+            self.current_bytes = 500000
+            self.generation = 1
+        def start(self):
+            pass
+        def stop(self):
+            pass
+        def pause(self):
+            self.is_paused = True
+            self.is_pause_requested = True
+        def resume(self):
+            self.is_paused = False
+            self.is_pause_requested = False
+        def format_bytes(self, b, **kw):
+            return "500.00 KB"
+
+    mock_worker = MockWorker()
+    from ui.dialogs import DownloadProgressDialog
+    dlg = DownloadProgressDialog(mock_worker, None)
+    dlg.hide()
+    window.active_downloads[key] = dlg
+    mock_worker.main_progress_signal.connect(lambda _, data: window.update_download_row(item0, data))
+
+    window.download_table.selectRow(row)
+
+    # Initial active progress tick (50.00%, Downloading)
+    window.update_download_row(item0, (
+        "test_lifecycle.iso", "1.00 MB", "Receiving data...", "10s", "50.00 KB/s", 500000, 1000000, 50000, 1
+    ))
+    assert window.download_table.item(row, 2).text() == "50.00%"
+    assert window._is_row_active(row) is True
+    assert window.action_stop.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
+
+    # 1. TOOLBAR PAUSE & RESUME
+    window.action_stop.trigger()
+    assert mock_worker.is_paused is True
+    assert item0.data(Qt.ItemDataRole.UserRole + 11) == "Paused"
+    assert window.download_table.item(row, 2).text() == "50.00%"
+    assert window._is_row_active(row) is False
+    assert window.action_stop.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
+
+    # Stale in-flight callback from older session arriving while paused -> discarded
+    window.update_download_row(item0, (
+        "test_lifecycle.iso", "1.00 MB", "Receiving data...", "9s", "60.00 KB/s", 510000, 1000000, 60000, 0
+    ))
+    assert window.download_table.item(row, 2).text() == "50.00%"
+    assert window._is_row_active(row) is False
+
+    # Toolbar Resume
+    window.action_resume.trigger()
+    assert mock_worker.is_paused is False
+    assert item0.data(Qt.ItemDataRole.UserRole + 11) == "Normal"
+    assert window._is_row_active(row) is True
+    assert window.action_stop.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
+
+    # 2. DOWNLOAD WINDOW (DIALOG) PAUSE & RESUME
+    dlg.btn_pause.setText("Pause")
+    dlg.toggle_pause()
+    assert mock_worker.is_paused is True
+    assert window._is_row_active(row) is False
+    assert window.action_stop.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
+
+    dlg.btn_pause.setText("Resume")
+    dlg.toggle_pause()
+    assert mock_worker.is_paused is False
+    assert window._is_row_active(row) is True
+    assert window.action_stop.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
+
+    # 3. RIGHT-CLICK CONTEXT MENU PAUSE & RESUME
+    window.stop_selected_download()
+    assert mock_worker.is_paused is True
+    assert window._is_row_active(row) is False
+    assert window.action_stop.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
+
+    window.resume_selected_download()
+    assert mock_worker.is_paused is False
+    assert window._is_row_active(row) is True
+    assert window.action_stop.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
+
+    # 4. CROSS-INTERFACE ALTERNATING SWITCHES
+    # Toolbar Pause -> Window Resume
+    window.action_stop.trigger()
+    assert window._is_row_active(row) is False
+    dlg.btn_pause.setText("Resume")
+    dlg.toggle_pause()
+    assert window._is_row_active(row) is True
+
+    # Window Pause -> Context Menu Resume
+    dlg.btn_pause.setText("Pause")
+    dlg.toggle_pause()
+    assert window._is_row_active(row) is False
+    window.resume_selected_download()
+    assert window._is_row_active(row) is True
+
+    # Context Menu Pause -> Toolbar Resume
+    window.stop_selected_download()
+    assert window._is_row_active(row) is False
+    window.action_resume.trigger()
+    assert window._is_row_active(row) is True
+
+    dlg.close()
+    dlg.deleteLater()
+
+
+
 
 
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -22,3 +22,19 @@ def test_aria2_worker_format_bytes(qapp):
 def test_fetcher_worker_format_bytes(qapp):
     fetcher = FileInfoFetcherWorker("http://example.com")
     assert fetcher.format_bytes(4096, precision=2, pad=False) == "4.00  KB"
+
+def test_workers_respect_configured_max_connections(qapp, monkeypatch, tmp_path):
+    from core.utils import save_extension_config, load_extension_config
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    save_extension_config({"protocol": "ws", "port": 56800, "token": "", "max_connections": 12})
+    cfg = load_extension_config()
+    assert cfg["max_connections"] == 12
+
+    # Verify clamping
+    save_extension_config({"max_connections": 999})
+    assert load_extension_config()["max_connections"] == 32
+
+    save_extension_config({"max_connections": 0})
+    assert load_extension_config()["max_connections"] == 1
+


### PR DESCRIPTION
## Summary

This PR introduces configurable split connection counts across download backends, stabilizes the download progress details view layout, implements an IDM-style state machine architecture to eliminate table flickering during pause/resume, and integrates GitHub Artifact Attestations for stable releases.

---

### 🚀 Key Features & Architectural Improvements

#### 1. Configurable Split Connections (`1`–`32`, default `8`)
- **Options Dialog**: Added `spin_max_conn` under **Engine Settings** in the **General Tab**.
- **Storage & Sanitization**: Config stored in `extension.json` and clamped in `src/core/utils.py` (`load_extension_config`).
- **Engine Propagation**: Dynamically adjusts connection parameters across `Aria2Worker` (Aria2 RPC `split` / `max-connection-per-server`), `Aria2DaemonManager`, and `DownloadWorker`.

#### 2. Responsive Progress Dialog & Segment Sizing (`520x465`)
- **Layout Invariance**: Preserves classic IDM window geometry (`520x465`) without vertical stretching.
- **Dynamic Segment Allocation**:
  - For $\le 8$ connections: Renders minimum 8 rows with `-`, `-`, `Unused` placeholders for layout consistency.
  - For $> 8$ connections (up to 32): Allocates required rows dynamically with native QTableWidget vertical scrolling.

#### 3. IDM State Architecture & Flicker Elimination
- **User Intent as Supreme Authority**:
  - Stored in table item data (`Qt.ItemDataRole.UserRole + 11`: `"Normal"`, `"Paused"`, `"Cancelled"`, `"Complete"`).
  - Explicit user actions immediately control UI state; asynchronous delayed packets from worker threads are dropped and cannot overwrite the `"Paused"` state.
- **Central State Resolver (`_get_display_state`)**:
  - Single source of truth translating `(user_state, engine_state, progress_percent)` into UI status labels and active bold styling.
- **Session Generation Tracking (`generation` ID)**:
  - Generation counters increment on every start/resume (`UserRole + 13`). Worker callbacks from previous epochs (`callback_gen < current_gen`) are rejected.
- **In-Place Toolbar Pause & Resume**:
  - Aligned toolbar buttons with progress dialog toggle behavior (`worker.pause()` / `worker.resume()` in-place without thread teardown or popup jitter).

#### 4. Table Performance & Re-sort Storm Guards
- Wrapped batch row mutations (`resume_selected_download`, `stop_selected_download`, `stop_all_downloads`, `download_finished`) in `setSortingEnabled(False)` and `blockSignals(True)`.
- Added atomic row viewport invalidation (`_set_row_bold`) to update all 7 columns simultaneously during font weight transitions.

#### 5. QML Card Synchronization
- Replaced `filteredModel.clear()` with index-by-index in-place mutation (`filteredModel.set(j, item)`) in `Main.qml` to prevent card delegate recreation and scroll jitter.

#### 6. Supply Chain Security (GitHub Artifact Attestations)
- Configured [`actions/attest@v4`](https://github.com/actions/attest) in `.github/workflows/release.yml` with `id-token: write` and `attestations: write` permissions.
- Automatically generates Sigstore build provenance attestations for all release artifacts on stable releases.

---

### 🧪 Test Coverage & Validation

- Added Options dialog persistence and boundary validation tests (`tests/test_ui.py`).
- Added Progress dialog segment layout and scrolling tests for 1, 8, 10, 16, 32 connections (`tests/test_ui.py`).
- Added multi-interface lifecycle stress test (`test_pause_resume_multi_interface_lifecycle`) validating:
  - Toolbar Pause $\to$ Toolbar Resume
  - Download Window Pause $\to$ Download Window Resume
  - Context Menu Pause $\to$ Context Menu Resume
  - Cross-interface alternating sequences (Toolbar $\to$ Window $\to$ Context $\to$ Toolbar)
- **141/141 automated unit tests passing** via `pytest`.
