### PR TITLE
feat(extension): update version to 0.3 and implement stealth zero-history download transition

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,23 @@
+---
+title: Issue title
+about: Report a problem with Bengal Download Manager
+---
+
+### App Info
+- **App Version:** [e.g. 1.0.0]
+- **Package / Mode:** [e.g. Flatpak, Standalone Binary, Source]
+- **Architecture:** [e.g. x86_64, ARM64]
+
+### Description
+A clear and concise description of the issue.
+
+### Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+### Expected Behavior
+A clear description of what should happen.
+
+### Logs / Screenshots (Optional)
+Attach logs or screenshots if available.

--- a/extension/background.js
+++ b/extension/background.js
@@ -260,7 +260,7 @@ async function getCookiesForUrl(targetUrl, storeId) {
   }
 }
 
-// --- RESOLVE DOWNLOAD TARGET (handles HTML landing pages with meta refresh / direct mirror links) ---
+// --- RESOLVE DOWNLOAD TARGET (handles HTML landing pages vs binary file targets) ---
 async function resolveDownloadTarget(url, userAgent, cookies) {
   if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) {
     return { url, isHtmlLanding: false };
@@ -289,41 +289,9 @@ async function resolveDownloadTarget(url, userAgent, cookies) {
       return { url: finalUrl, isHtmlLanding: false };
     }
 
-    // For HTML responses, inspect the snippet for meta refresh or target file confirmation forms
     const text = await response.text();
 
-    // 1. Check for Meta Refresh tag (e.g. VideoLAN mirror redirect)
-    const metaMatch = text.match(/content=["']?\d+;\s*url=['"]?([^'"]+)/i)
-                   || text.match(/url=['"]?([^'"]+)['"]?[^>]*http-equiv/i);
-    if (metaMatch && metaMatch[1]) {
-      const cleanUrl = metaMatch[1].replace(/['"]$/, '').trim();
-      const resolvedTarget = new URL(cleanUrl, finalUrl).href;
-      return { url: resolvedTarget, isHtmlLanding: false };
-    }
-
-    // 2. Google Drive / Cloud storage download confirmation forms or links
-    const formMatch = text.match(/<form[^>]*id=["']download-form["'][^>]*action=["']([^"']+)["'][^>]*>([\s\S]*?)<\/form>/i)
-                   || text.match(/<form[^>]*action=["']([^"']+)["'][^>]*>([\s\S]*?)<\/form>/i);
-    if (formMatch) {
-      const formAction = formMatch[1].replace(/&amp;/g, '&');
-      const formInner = formMatch[2];
-
-      const inputs = [];
-      const inputRegex = /<input[^>]*name=["']([^"']+)["'][^>]*value=["']([^"']*)["']/gi;
-      let m;
-      while ((m = inputRegex.exec(formInner)) !== null) {
-        if (m[1] && m[1] !== 'submit') {
-          inputs.push(`${encodeURIComponent(m[1])}=${encodeURIComponent(m[2])}`);
-        }
-      }
-
-      if (inputs.length > 0) {
-        const baseUrl = new URL(formAction, finalUrl).href;
-        const confirmUrl = baseUrl + (baseUrl.includes('?') ? '&' : '?') + inputs.join('&');
-        return { url: confirmUrl, isHtmlLanding: false };
-      }
-    }
-
+    // Google Drive large file direct confirmation links
     const gdriveConfirmMatch = text.match(/id=["']uc-download-link["'][^>]*href=["']([^"']+)["']/i)
                             || text.match(/href=["'](\/uc\?export=download&[^"']+)["']/i)
                             || text.match(/href=["'](https:\/\/[^"']*googleusercontent\.com\/[^"']+)["']/i)
@@ -334,7 +302,6 @@ async function resolveDownloadTarget(url, userAgent, cookies) {
       return { url: resolvedTarget, isHtmlLanding: false };
     }
 
-    // Pure HTML landing page with no extractable redirect/confirmation
     return { url: finalUrl, isHtmlLanding: true };
   } catch (err) {
     console.warn("Could not resolve download target:", err);

--- a/extension/background.js
+++ b/extension/background.js
@@ -27,6 +27,7 @@ function getFileExtension(urlOrFilename) {
 async function getFilterRules() {
   return new Promise((resolve) => {
     chrome.storage.local.get({
+      enableInterception: true,
       whitelistUrls: [],
       whitelistExts: [],
       blacklistUrls: [],
@@ -35,13 +36,85 @@ async function getFilterRules() {
   });
 }
 
-function matchesUrlOrDomain(url, urlPatterns) {
-  if (!url || !Array.isArray(urlPatterns) || urlPatterns.length === 0) return false;
-  const urlLower = url.toLowerCase();
+function parseDomainAndPath(rawInput) {
+  if (!rawInput || typeof rawInput !== 'string') return { hostname: "", pathname: "", raw: "" };
+  let str = rawInput.trim().toLowerCase();
+  // Strip wildcard prefix if present e.g. *.example.com -> example.com
+  let hasWildcard = false;
+  if (str.startsWith('*.')) {
+    hasWildcard = true;
+    str = str.substring(2);
+  } else if (str.startsWith('*')) {
+    hasWildcard = true;
+    str = str.substring(1);
+  }
+
+  // Prepend dummy protocol if missing to parse cleanly via URL parser
+  let toParse = str;
+  if (!toParse.includes('://')) {
+    toParse = 'http://' + toParse;
+  }
+
+  try {
+    const parsed = new URL(toParse);
+    let hostname = parsed.hostname.toLowerCase();
+    let pathname = parsed.pathname || "";
+    if (pathname === '/') pathname = "";
+    return { hostname, pathname, hasWildcard, raw: str };
+  } catch (e) {
+    return { hostname: str.replace(/\/.*$/, ''), pathname: "", hasWildcard, raw: str };
+  }
+}
+
+function matchesUrlOrDomain(targetUrl, urlPatterns, referrerUrl) {
+  if (!Array.isArray(urlPatterns) || urlPatterns.length === 0) return false;
+  
+  const targets = [];
+  if (targetUrl) targets.push(targetUrl);
+  if (referrerUrl && typeof referrerUrl === 'string' && referrerUrl.startsWith('http')) {
+    targets.push(referrerUrl);
+  }
+  if (targets.length === 0) return false;
+
   for (const pattern of urlPatterns) {
-    const p = pattern.trim().toLowerCase();
-    if (!p) continue;
-    if (urlLower.includes(p)) return true;
+    if (!pattern || typeof pattern !== 'string') continue;
+    const pInfo = parseDomainAndPath(pattern);
+    if (!pInfo.hostname && !pInfo.raw) continue;
+
+    for (const testUrl of targets) {
+      const urlLower = testUrl.toLowerCase();
+      const tInfo = parseDomainAndPath(urlLower);
+
+      // Direct substring match if pattern specifies specific path or query
+      if (pInfo.pathname && urlLower.includes(pInfo.raw)) {
+        return true;
+      }
+
+      // Hostname comparison
+      if (pInfo.hostname && tInfo.hostname) {
+        if (tInfo.hostname === pInfo.hostname) {
+          // If pattern also has pathname requirement
+          if (pInfo.pathname) {
+            if (tInfo.pathname.startsWith(pInfo.pathname)) return true;
+          } else {
+            return true;
+          }
+        }
+        // Subdomain matching (e.g. sub.mirror.xeonbd.com matches mirror.xeonbd.com or xeonbd.com)
+        if (tInfo.hostname.endsWith('.' + pInfo.hostname)) {
+          if (pInfo.pathname) {
+            if (tInfo.pathname.startsWith(pInfo.pathname)) return true;
+          } else {
+            return true;
+          }
+        }
+      }
+
+      // Fallback substring search for raw pattern if user typed partial keyword
+      if (pInfo.raw && urlLower.includes(pInfo.raw)) {
+        return true;
+      }
+    }
   }
   return false;
 }
@@ -62,14 +135,18 @@ function matchesExtension(extOrFilename, extList) {
   return false;
 }
 
-async function shouldInterceptDownload(url, filename) {
+async function shouldInterceptDownload(url, filename, referrer) {
   if (!url || isIgnoredServiceUrl(url)) return false;
 
-  const ext = getFileExtension(filename || url);
   const rules = await getFilterRules();
+  if (rules.enableInterception === false) {
+    return false;
+  }
 
-  // 1. Blacklist check - if matched, do NOT intercept (leave to browser)
-  if (matchesUrlOrDomain(url, rules.blacklistUrls) || matchesExtension(ext || filename, rules.blacklistExts)) {
+  const ext = getFileExtension(filename || url);
+
+  // 1. Blacklist check - if matched on URL, domain, referrer, or extension: do NOT intercept (leave to browser)
+  if (matchesUrlOrDomain(url, rules.blacklistUrls, referrer) || matchesExtension(ext || filename, rules.blacklistExts)) {
     return false;
   }
 
@@ -84,7 +161,7 @@ async function shouldInterceptDownload(url, filename) {
   }
 
   // 4. Whitelisted URL/domain - intercept downloadable files on this domain
-  if (matchesUrlOrDomain(url, rules.whitelistUrls)) {
+  if (matchesUrlOrDomain(url, rules.whitelistUrls, referrer)) {
     return true;
   }
 
@@ -415,19 +492,15 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
         const ext = getFileExtension(filenameFromHeader || details.url);
 
         (async () => {
+          const ext = getFileExtension(filenameFromHeader || details.url);
+          const referrer = details.initiator || details.documentUrl || "";
+          const shouldIntercept = await shouldInterceptDownload(details.url, filenameFromHeader, referrer);
+          if (!shouldIntercept) {
+            return;
+          }
+
           const rules = await getFilterRules();
-
-          // 1. Blacklist check - never intercept
-          if (matchesUrlOrDomain(details.url, rules.blacklistUrls) || matchesExtension(ext || filenameFromHeader, rules.blacklistExts)) {
-            return;
-          }
-
-          // 2. Default ignored web extensions (manifest.json, html, js, css, web images) MUST NOT be intercepted unless specifically whitelisted
           const isExplicitWhitelistedExt = matchesExtension(ext || filenameFromHeader, rules.whitelistExts);
-          if (ext && DEFAULT_IGNORED_EXTS.includes(ext) && !isExplicitWhitelistedExt) {
-            return;
-          }
-
           const isDownloadExt = ext && RECOGNIZED_DOWNLOAD_EXTS.includes(ext);
           const isGoogleDriveExport = details.url.includes("export=download") || details.url.includes("uc-download-link");
 
@@ -455,7 +528,7 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
               userAgent: navigator.userAgent,
               cookies: cookieString,
               filename: filenameFromHeader,
-              referrer: details.initiator || details.documentUrl || ""
+              referrer: referrer
             });
           }
         })();
@@ -520,7 +593,8 @@ if (chrome.downloads && chrome.downloads.onDeterminingFilename) {
     if (!downloadItem || !downloadItem.url || isIgnoredServiceUrl(downloadItem.url)) return;
 
     (async () => {
-      const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename);
+      const referrer = downloadItem.referrer || downloadItem.finalUrl || "";
+      const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename, referrer);
       if (!shouldIntercept) return;
 
       const isOnline = await isBengalDMOnline();
@@ -536,8 +610,9 @@ if (chrome.downloads && chrome.downloads.onCreated) {
   chrome.downloads.onCreated.addListener(async (downloadItem) => {
     if (!downloadItem || !downloadItem.url || isIgnoredServiceUrl(downloadItem.url)) return;
 
+    const referrer = downloadItem.referrer || downloadItem.finalUrl || "";
     // Check Whitelist & Blacklist rules
-    const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename);
+    const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename, referrer);
     if (!shouldIntercept) {
       return; // Leave download to native browser
     }
@@ -579,7 +654,7 @@ if (chrome.downloads && chrome.downloads.onCreated) {
       userAgent: navigator.userAgent,
       cookies: cookieString,
       filename: downloadItem.filename || "",
-      referrer: downloadItem.referrer || ""
+      referrer: referrer
     });
   });
 }
@@ -638,7 +713,7 @@ function sanitizeMediaUrl(url) {
         return parsed.toString();
       }
     } else if (hostname.includes("tiktok.com")) {
-      for (const k of ["is_from_webapp", "sender_device", "share_app_id", "share_item_id", "share_link_id"]) {
+      for (const k of ["is_fromwebapp", "sender_device", "share_app_id", "share_item_id", "share_link_id"]) {
         parsed.searchParams.delete(k);
       }
       return parsed.toString();
@@ -738,9 +813,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           url: cleanUrl,
           userAgent: navigator.userAgent,
           cookies: cookieString,
-          referrer: request.url
+          referrer: request.referrer || request.url
         });
         sendResponse({ success, resolvedUrl: cleanUrl });
+        return;
+      }
+
+      // Check filters
+      const shouldIntercept = await shouldInterceptDownload(request.url, request.filename, request.referrer);
+      if (!shouldIntercept) {
+        sendResponse({ success: false, bypassed: true });
         return;
       }
 
@@ -762,7 +844,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         url: resolved.url,
         userAgent: navigator.userAgent,
         cookies: cookieString,
-        referrer: request.url
+        referrer: request.referrer || request.url
       });
       sendResponse({ success, resolvedUrl: resolved.url });
     })();
@@ -772,19 +854,25 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "check_status") {
     (async () => {
       const isOnline = await isBengalDMOnline();
+      const rules = await getFilterRules();
       let blacklisted = false;
       let whitelistedUrl = false;
       let whitelistedExt = false;
 
       if (request.url) {
         const ext = getFileExtension(request.url);
-        const rules = await getFilterRules();
-        blacklisted = matchesUrlOrDomain(request.url, rules.blacklistUrls) || matchesExtension(ext, rules.blacklistExts);
-        whitelistedUrl = matchesUrlOrDomain(request.url, rules.whitelistUrls);
+        blacklisted = matchesUrlOrDomain(request.url, rules.blacklistUrls, request.referrer) || matchesExtension(ext, rules.blacklistExts);
+        whitelistedUrl = matchesUrlOrDomain(request.url, rules.whitelistUrls, request.referrer);
         whitelistedExt = matchesExtension(ext, rules.whitelistExts);
       }
 
-      sendResponse({ online: isOnline, blacklisted, whitelistedUrl, whitelistedExt });
+      sendResponse({
+        online: isOnline,
+        enableInterception: rules.enableInterception !== false,
+        blacklisted,
+        whitelistedUrl,
+        whitelistedExt
+      });
     })();
     return true;
   }

--- a/extension/background.js
+++ b/extension/background.js
@@ -24,15 +24,37 @@ function getFileExtension(urlOrFilename) {
 }
 
 // --- WHITELIST & BLACKLIST FILTER RULES ---
+let cachedFilterRules = {
+  enableInterception: true,
+  whitelistUrls: [],
+  whitelistExts: [],
+  blacklistUrls: [],
+  blacklistExts: []
+};
+
+function refreshFilterRules() {
+  chrome.storage.local.get(cachedFilterRules, (items) => {
+    cachedFilterRules = { ...cachedFilterRules, ...items };
+  });
+}
+refreshFilterRules();
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === 'local') {
+    for (const key of ['enableInterception', 'whitelistUrls', 'whitelistExts', 'blacklistUrls', 'blacklistExts']) {
+      if (changes[key] !== undefined) {
+        cachedFilterRules[key] = changes[key].newValue;
+      }
+    }
+  }
+});
+
 async function getFilterRules() {
   return new Promise((resolve) => {
-    chrome.storage.local.get({
-      enableInterception: true,
-      whitelistUrls: [],
-      whitelistExts: [],
-      blacklistUrls: [],
-      blacklistExts: []
-    }, resolve);
+    chrome.storage.local.get(cachedFilterRules, (items) => {
+      cachedFilterRules = { ...cachedFilterRules, ...items };
+      resolve(cachedFilterRules);
+    });
   });
 }
 
@@ -135,10 +157,10 @@ function matchesExtension(extOrFilename, extList) {
   return false;
 }
 
-async function shouldInterceptDownload(url, filename, referrer) {
+function shouldInterceptDownloadSync(url, filename, referrer) {
   if (!url || isIgnoredServiceUrl(url)) return false;
 
-  const rules = await getFilterRules();
+  const rules = cachedFilterRules;
   if (rules.enableInterception === false) {
     return false;
   }
@@ -166,6 +188,10 @@ async function shouldInterceptDownload(url, filename, referrer) {
   }
 
   return true;
+}
+
+async function shouldInterceptDownload(url, filename, referrer) {
+  return shouldInterceptDownloadSync(url, filename, referrer);
 }
 
 // --- ENHANCED COOKIE EXTRACTION (cliget method with Firefox storeId & dFPI support) ---
@@ -490,22 +516,21 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
         }
 
         const ext = getFileExtension(filenameFromHeader || details.url);
+        const referrer = details.initiator || details.documentUrl || "";
 
-        (async () => {
-          const ext = getFileExtension(filenameFromHeader || details.url);
-          const referrer = details.initiator || details.documentUrl || "";
-          const shouldIntercept = await shouldInterceptDownload(details.url, filenameFromHeader, referrer);
-          if (!shouldIntercept) {
-            return;
-          }
+        // Synchronous blacklist & interception check
+        const shouldIntercept = shouldInterceptDownloadSync(details.url, filenameFromHeader, referrer);
+        if (!shouldIntercept) {
+          return; // Bypassed to native browser! NEVER cancel or redirect!
+        }
 
-          const rules = await getFilterRules();
-          const isExplicitWhitelistedExt = matchesExtension(ext || filenameFromHeader, rules.whitelistExts);
-          const isDownloadExt = ext && RECOGNIZED_DOWNLOAD_EXTS.includes(ext);
-          const isGoogleDriveExport = details.url.includes("export=download") || details.url.includes("uc-download-link");
+        const isExplicitWhitelistedExt = matchesExtension(ext || filenameFromHeader, cachedFilterRules.whitelistExts);
+        const isDownloadExt = ext && RECOGNIZED_DOWNLOAD_EXTS.includes(ext);
+        const isGoogleDriveExport = details.url.includes("export=download") || details.url.includes("uc-download-link");
 
-          // Only intercept if there is a real download intent
-          if (hasContentDispositionAttachment || isBinaryContentType || isDownloadExt || isExplicitWhitelistedExt || isGoogleDriveExport) {
+        // Only intercept if there is a real download intent
+        if (hasContentDispositionAttachment || isBinaryContentType || isDownloadExt || isExplicitWhitelistedExt || isGoogleDriveExport) {
+          (async () => {
             const isOnline = await isBengalDMOnline();
             if (!isOnline) return;
 
@@ -530,12 +555,9 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
               filename: filenameFromHeader,
               referrer: referrer
             });
-          }
-        })();
+          })();
 
-        if (extraSpec.includes("blocking")) {
-          // If blocking is supported (Firefox MV3/MV2), check synchronous cancellation
-          if (hasContentDispositionAttachment || isBinaryContentType || isDownloadExt || isExplicitWhitelistedExt) {
+          if (extraSpec.includes("blocking")) {
             return { cancel: true };
           }
         }
@@ -592,11 +614,13 @@ if (chrome.downloads && chrome.downloads.onDeterminingFilename) {
   chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
     if (!downloadItem || !downloadItem.url || isIgnoredServiceUrl(downloadItem.url)) return;
 
-    (async () => {
-      const referrer = downloadItem.referrer || downloadItem.finalUrl || "";
-      const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename, referrer);
-      if (!shouldIntercept) return;
+    const referrer = downloadItem.referrer || downloadItem.finalUrl || "";
+    const shouldIntercept = shouldInterceptDownloadSync(downloadItem.url, downloadItem.filename, referrer);
+    if (!shouldIntercept) {
+      return; // Leave download to native browser!
+    }
 
+    (async () => {
       const isOnline = await isBengalDMOnline();
       if (!isOnline) return;
 
@@ -612,9 +636,9 @@ if (chrome.downloads && chrome.downloads.onCreated) {
 
     const referrer = downloadItem.referrer || downloadItem.finalUrl || "";
     // Check Whitelist & Blacklist rules
-    const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename, referrer);
+    const shouldIntercept = shouldInterceptDownloadSync(downloadItem.url, downloadItem.filename, referrer);
     if (!shouldIntercept) {
-      return; // Leave download to native browser
+      return; // Leave download to native browser!
     }
 
     // 1. Verify if Bengal DM application is online

--- a/extension/background.js
+++ b/extension/background.js
@@ -260,7 +260,7 @@ async function getCookiesForUrl(targetUrl, storeId) {
   }
 }
 
-// --- RESOLVE DOWNLOAD TARGET (handles HTML landing pages vs binary file targets) ---
+// --- RESOLVE DOWNLOAD TARGET (handles HTML landing pages with meta refresh / direct mirror links) ---
 async function resolveDownloadTarget(url, userAgent, cookies) {
   if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) {
     return { url, isHtmlLanding: false };
@@ -289,9 +289,41 @@ async function resolveDownloadTarget(url, userAgent, cookies) {
       return { url: finalUrl, isHtmlLanding: false };
     }
 
+    // For HTML responses, inspect the snippet for meta refresh or target file confirmation forms
     const text = await response.text();
 
-    // Google Drive large file direct confirmation links
+    // 1. Check for Meta Refresh tag (e.g. VideoLAN mirror redirect, SourceForge)
+    const metaMatch = text.match(/content=["']?\d+;\s*url=['"]?([^'"]+)/i)
+                   || text.match(/url=['"]?([^'"]+)['"]?[^>]*http-equiv/i);
+    if (metaMatch && metaMatch[1]) {
+      const cleanUrl = metaMatch[1].replace(/['"]$/, '').trim();
+      const resolvedTarget = new URL(cleanUrl, finalUrl).href;
+      return { url: resolvedTarget, isHtmlLanding: false };
+    }
+
+    // 2. Google Drive / Cloud storage download confirmation forms or links
+    const formMatch = text.match(/<form[^>]*id=["']download-form["'][^>]*action=["']([^"']+)["'][^>]*>([\s\S]*?)<\/form>/i)
+                   || text.match(/<form[^>]*action=["']([^"']+)["'][^>]*>([\s\S]*?)<\/form>/i);
+    if (formMatch) {
+      const formAction = formMatch[1].replace(/&amp;/g, '&');
+      const formInner = formMatch[2];
+
+      const inputs = [];
+      const inputRegex = /<input[^>]*name=["']([^"']+)["'][^>]*value=["']([^"']*)["']/gi;
+      let m;
+      while ((m = inputRegex.exec(formInner)) !== null) {
+        if (m[1] && m[1] !== 'submit') {
+          inputs.push(`${encodeURIComponent(m[1])}=${encodeURIComponent(m[2])}`);
+        }
+      }
+
+      if (inputs.length > 0) {
+        const baseUrl = new URL(formAction, finalUrl).href;
+        const confirmUrl = baseUrl + (baseUrl.includes('?') ? '&' : '?') + inputs.join('&');
+        return { url: confirmUrl, isHtmlLanding: false };
+      }
+    }
+
     const gdriveConfirmMatch = text.match(/id=["']uc-download-link["'][^>]*href=["']([^"']+)["']/i)
                             || text.match(/href=["'](\/uc\?export=download&[^"']+)["']/i)
                             || text.match(/href=["'](https:\/\/[^"']*googleusercontent\.com\/[^"']+)["']/i)
@@ -302,6 +334,7 @@ async function resolveDownloadTarget(url, userAgent, cookies) {
       return { url: resolvedTarget, isHtmlLanding: false };
     }
 
+    // Pure HTML landing page with no extractable redirect/confirmation
     return { url: finalUrl, isHtmlLanding: true };
   } catch (err) {
     console.warn("Could not resolve download target:", err);

--- a/extension/background.js
+++ b/extension/background.js
@@ -461,7 +461,10 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
         })();
 
         if (extraSpec.includes("blocking")) {
-          // If blocking is supported, we check synchronicity if available
+          // If blocking is supported (Firefox MV3/MV2), check synchronous cancellation
+          if (hasContentDispositionAttachment || isBinaryContentType || isDownloadExt || isExplicitWhitelistedExt) {
+            return { cancel: true };
+          }
         }
       },
       { urls: ["<all_urls>"], types: ["main_frame", "sub_frame", "other"] },
@@ -473,10 +476,62 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
   const hasBlocking = manifest.permissions && Array.isArray(manifest.permissions) && manifest.permissions.includes('webRequestBlocking');
   const extraSpec = hasBlocking ? ["responseHeaders", "blocking"] : ["responseHeaders"];
 
-  setupListener(extraSpec);
+  try {
+    setupListener(extraSpec);
+  } catch {
+    setupListener(["responseHeaders"]);
+  }
 }
 
-// --- BROWSER DOWNLOAD CANCELLER & TAKEOVER (Guarantees zero browser downloads when Bengal DM is running) ---
+// --- BROWSER DOWNLOAD CANCELLER & TAKEOVER (Zero-Popup, Zero-Animation, Zero-History) ---
+const interceptedDownloadIds = new Set();
+
+function eraseDownloadRecord(downloadId) {
+  if (!downloadId || !chrome.downloads || !chrome.downloads.erase) return;
+  try {
+    chrome.downloads.erase({ id: downloadId }, () => {
+      if (chrome.runtime && chrome.runtime.lastError) { /* ignore */ }
+    });
+  } catch {}
+}
+
+function cancelAndEraseDownload(downloadId) {
+  if (!downloadId || !chrome.downloads) return;
+  interceptedDownloadIds.add(downloadId);
+  try {
+    chrome.downloads.cancel(downloadId, () => {
+      eraseDownloadRecord(downloadId);
+    });
+  } catch {}
+  eraseDownloadRecord(downloadId);
+  setTimeout(() => eraseDownloadRecord(downloadId), 40);
+  setTimeout(() => eraseDownloadRecord(downloadId), 150);
+  setTimeout(() => eraseDownloadRecord(downloadId), 500);
+}
+
+// Disable download shelf UI if supported by browser build
+if (chrome.downloads && typeof chrome.downloads.setShelfEnabled === 'function') {
+  try { chrome.downloads.setShelfEnabled(false); } catch {}
+}
+
+// 1. Hook onDeterminingFilename (Chrome/Edge): Cancels before Save-As dialog opens and before download animation triggers
+if (chrome.downloads && chrome.downloads.onDeterminingFilename) {
+  chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
+    if (!downloadItem || !downloadItem.url || isIgnoredServiceUrl(downloadItem.url)) return;
+
+    (async () => {
+      const shouldIntercept = await shouldInterceptDownload(downloadItem.url, downloadItem.filename);
+      if (!shouldIntercept) return;
+
+      const isOnline = await isBengalDMOnline();
+      if (!isOnline) return;
+
+      cancelAndEraseDownload(downloadItem.id);
+    })();
+  });
+}
+
+// 2. Hook onCreated: Initial download instantiation and handover to Bengal DM
 if (chrome.downloads && chrome.downloads.onCreated) {
   chrome.downloads.onCreated.addListener(async (downloadItem) => {
     if (!downloadItem || !downloadItem.url || isIgnoredServiceUrl(downloadItem.url)) return;
@@ -494,20 +549,7 @@ if (chrome.downloads && chrome.downloads.onCreated) {
     }
 
     // 2. Bengal DM is active: cancel and erase browser native download immediately on 0th byte
-    try {
-      chrome.downloads.cancel(downloadItem.id, () => {
-        try { chrome.downloads.erase({ id: downloadItem.id }); } catch (e) {}
-      });
-      setTimeout(() => {
-        try {
-          chrome.downloads.cancel(downloadItem.id, () => {
-            try { chrome.downloads.erase({ id: downloadItem.id }); } catch (e) {}
-          });
-        } catch (e) {}
-      }, 50);
-    } catch (e) {
-      try { chrome.downloads.erase({ id: downloadItem.id }); } catch (err) {}
-    }
+    cancelAndEraseDownload(downloadItem.id);
 
     // 3. Deduplicate if already processed by content script or webRequest
     if (isRecentlySent(downloadItem.url, downloadItem.filename)) return;
@@ -539,6 +581,18 @@ if (chrome.downloads && chrome.downloads.onCreated) {
       filename: downloadItem.filename || "",
       referrer: downloadItem.referrer || ""
     });
+  });
+}
+
+// 3. Hook onChanged: Erase the download from history database the moment state reaches "interrupted"
+if (chrome.downloads && chrome.downloads.onChanged) {
+  chrome.downloads.onChanged.addListener((delta) => {
+    if (!delta || !delta.id) return;
+    if (interceptedDownloadIds.has(delta.id) || (delta.state && delta.state.current === "interrupted")) {
+      eraseDownloadRecord(delta.id);
+      setTimeout(() => eraseDownloadRecord(delta.id), 80);
+      setTimeout(() => eraseDownloadRecord(delta.id), 300);
+    }
   });
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -40,13 +40,17 @@ document.addEventListener('click', (event) => {
     }
 
     // Query background service to check Bengal DM backend status & filtering rules
-    chrome.runtime.sendMessage({ action: "check_status", url: link.href }, (statusResponse) => {
+    chrome.runtime.sendMessage({
+      action: "check_status",
+      url: link.href,
+      referrer: window.location.href
+    }, (statusResponse) => {
       if (chrome.runtime.lastError || !statusResponse || !statusResponse.online) {
         return;
       }
 
-      // If blacklisted, leave to browser
-      if (statusResponse.blacklisted) {
+      // If global interception is disabled or website/URL is blacklisted, leave to browser
+      if (statusResponse.enableInterception === false || statusResponse.blacklisted) {
         return;
       }
 
@@ -67,7 +71,8 @@ document.addEventListener('click', (event) => {
 
       chrome.runtime.sendMessage({
         action: "send_to_bengal",
-        url: link.href
+        url: link.href,
+        referrer: window.location.href
       }, (response) => {
         if (response && response.isHtmlLanding) {
           // HTML web page target: open normally in browser tab

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bengal DM Integration Module",
-  "version": "0.2",
+  "version": "0.3",
   "description": "Integrates your browser with Bengal Download Manager for fast, multi-threaded downloads.",
   "icons": {
     "16": "assets/icon-16.png",
@@ -39,6 +39,7 @@
     "storage",
     "contextMenus",
     "webRequest",
+    "webRequestBlocking",
     "cookies",
     "notifications"
   ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -41,7 +41,9 @@
     "webRequest",
     "webRequestBlocking",
     "cookies",
-    "notifications"
+    "notifications",
+    "activeTab",
+    "tabs"
   ],
   "host_permissions": [
     "http://127.0.0.1/*",

--- a/extension/options.css
+++ b/extension/options.css
@@ -527,12 +527,27 @@ body {
 /* Listbox (Firefox Setting / Exceptions Style) */
 .tag-input-row {
   display: flex;
+  align-items: stretch;
   gap: 8px;
   margin-bottom: 10px;
+  width: 100%;
 }
 
 .tag-input-row .form-input {
-  flex-grow: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tag-input-row .btn {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 16px;
+  min-width: 80px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .listbox-container {

--- a/extension/options.css
+++ b/extension/options.css
@@ -489,62 +489,136 @@ body {
   color: var(--text-muted);
 }
 
-/* Tags & Tag Input */
+/* Toggle Control Label */
+.toggle-control-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  cursor: pointer;
+  padding: 8px 0;
+  user-select: none;
+}
+
+.toggle-control-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: var(--bdm-highlight);
+  cursor: pointer;
+}
+
+.toggle-control-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toggle-control-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.toggle-control-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Listbox (Firefox Setting / Exceptions Style) */
 .tag-input-row {
   display: flex;
   gap: 8px;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .tag-input-row .form-input {
   flex-grow: 1;
 }
 
-.tags-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  min-height: 38px;
-  padding: 8px;
+.listbox-container {
+  max-height: 180px;
+  min-height: 90px;
+  overflow-y: auto;
   background-color: var(--bg-input);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
+  padding: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
 }
 
-.tags-container:empty::before {
-  content: "No filter items configured.";
+.listbox-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.listbox-container::-webkit-scrollbar-thumb {
+  background-color: var(--border-color);
+  border-radius: 3px;
+}
+
+.listbox-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.listbox-items:empty::before {
+  content: "No items configured.";
   font-size: 12px;
   color: var(--text-muted);
   font-style: italic;
-  padding: 4px;
+  padding: 12px;
+  display: block;
+  text-align: center;
 }
 
-.tag-chip {
-  display: inline-flex;
+.listbox-row {
+  display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  background-color: var(--bg-tag);
-  border: 1px solid var(--border-color);
-  border-radius: 14px;
-  font-size: 12px;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12.5px;
   font-weight: 500;
   color: var(--text-main);
+  background-color: transparent;
+  transition: background-color var(--transition);
 }
 
-.tag-remove {
+.listbox-row:nth-child(even) {
+  background-color: rgba(128, 128, 128, 0.04);
+}
+
+.listbox-row:hover {
+  background-color: var(--bg-tag);
+}
+
+.listbox-text {
+  flex-grow: 1;
+  word-break: break-all;
+  font-family: monospace, var(--font-family);
+  font-size: 12px;
+}
+
+.listbox-remove {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 16px;
   color: var(--text-muted);
   line-height: 1;
+  padding: 2px 6px;
+  border-radius: 4px;
   display: flex;
   align-items: center;
+  justify-content: center;
+  transition: color var(--transition), background-color var(--transition);
 }
 
-.tag-remove:hover {
+.listbox-remove:hover {
   color: var(--bdm-error);
+  background-color: rgba(239, 68, 68, 0.12);
 }
 
 /* About Grid */

--- a/extension/options.html
+++ b/extension/options.html
@@ -88,6 +88,19 @@
             <button id="reset" class="btn btn-subtle">Reset Defaults</button>
           </div>
         </div>
+
+        <div class="card">
+          <div class="card-title">Download Interception</div>
+          <p class="card-desc">Control whether this extension automatically intercepts file downloads from the browser.</p>
+
+          <label class="toggle-control-label">
+            <input type="checkbox" id="options-enable-interception" checked>
+            <div class="toggle-control-text">
+              <span class="toggle-control-title">Capture browser downloads</span>
+              <span class="toggle-control-desc">Automatically route eligible downloads to Bengal DM</span>
+            </div>
+          </label>
+        </div>
       </section>
 
       <!-- Tab: Appearance -->
@@ -160,7 +173,9 @@
             <input type="text" id="whitelist-url-input" class="form-input" placeholder="Add domain or URL pattern (e.g. example.com)">
             <button id="add-whitelist-url" class="btn btn-secondary">Add URL</button>
           </div>
-          <div id="whitelist-url-tags" class="tags-container"></div>
+          <div class="listbox-container">
+            <div id="whitelist-url-tags" class="listbox-items"></div>
+          </div>
         </div>
 
         <div class="card">
@@ -171,7 +186,9 @@
             <input type="text" id="whitelist-ext-input" class="form-input" placeholder="Add extension (e.g. .iso, .zip, .exe)">
             <button id="add-whitelist-ext" class="btn btn-secondary">Add Extension</button>
           </div>
-          <div id="whitelist-ext-tags" class="tags-container"></div>
+          <div class="listbox-container">
+            <div id="whitelist-ext-tags" class="listbox-items"></div>
+          </div>
         </div>
       </section>
 
@@ -187,10 +204,12 @@
           <p class="card-desc">Never intercept downloads from these websites or URL patterns.</p>
           
           <div class="tag-input-row">
-            <input type="text" id="blacklist-url-input" class="form-input" placeholder="Add domain or URL pattern (e.g. adsite.com)">
+            <input type="text" id="blacklist-url-input" class="form-input" placeholder="Add domain or URL pattern (e.g. adsite.com, mirror.xeonbd.com)">
             <button id="add-blacklist-url" class="btn btn-secondary">Add URL</button>
           </div>
-          <div id="blacklist-url-tags" class="tags-container"></div>
+          <div class="listbox-container">
+            <div id="blacklist-url-tags" class="listbox-items"></div>
+          </div>
         </div>
 
         <div class="card">
@@ -201,7 +220,9 @@
             <input type="text" id="blacklist-ext-input" class="form-input" placeholder="Add extension (e.g. .pdf, .docx, .png)">
             <button id="add-blacklist-ext" class="btn btn-secondary">Add Extension</button>
           </div>
-          <div id="blacklist-ext-tags" class="tags-container"></div>
+          <div class="listbox-container">
+            <div id="blacklist-ext-tags" class="listbox-items"></div>
+          </div>
         </div>
       </section>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -184,21 +184,41 @@ const filterLists = {
   blacklistExts: []
 };
 
+function normalizeUrlOrDomainInput(input) {
+  if (!input || typeof input !== 'string') return "";
+  let val = input.trim().toLowerCase();
+  // If user pasted a full URL with protocol and no path or just root path e.g. https://mirror.xeonbd.com/
+  try {
+    if (val.startsWith('http://') || val.startsWith('https://')) {
+      const parsed = new URL(val);
+      if (!parsed.pathname || parsed.pathname === '/') {
+        return parsed.hostname;
+      }
+      return parsed.hostname + parsed.pathname.replace(/\/$/, '');
+    }
+  } catch (e) {}
+
+  // Strip trailing slash
+  val = val.replace(/\/+$/, '');
+  return val;
+}
+
 function renderTagList(containerId, listKey) {
   const container = document.getElementById(containerId);
   if (!container) return;
   container.innerHTML = '';
 
   filterLists[listKey].forEach((item, index) => {
-    const chip = document.createElement('div');
-    chip.className = 'tag-chip';
+    const row = document.createElement('div');
+    row.className = 'listbox-row';
 
     const textSpan = document.createElement('span');
+    textSpan.className = 'listbox-text';
     textSpan.textContent = item;
-    chip.appendChild(textSpan);
+    row.appendChild(textSpan);
 
     const removeBtn = document.createElement('button');
-    removeBtn.className = 'tag-remove';
+    removeBtn.className = 'listbox-remove';
     removeBtn.innerHTML = '&times;';
     removeBtn.title = 'Remove';
     removeBtn.addEventListener('click', () => {
@@ -210,8 +230,8 @@ function renderTagList(containerId, listKey) {
       chrome.storage.local.set(updatePayload);
     });
 
-    chip.appendChild(removeBtn);
-    container.appendChild(chip);
+    row.appendChild(removeBtn);
+    container.appendChild(row);
   });
 }
 
@@ -228,9 +248,11 @@ function setupFilterInput(inputId, buttonId, containerId, listKey, isExtension =
       if (!val.startsWith('.')) {
         val = '.' + val;
       }
+    } else {
+      val = normalizeUrlOrDomainInput(val);
     }
 
-    if (!filterLists[listKey].includes(val)) {
+    if (val && !filterLists[listKey].includes(val)) {
       filterLists[listKey].push(val);
       renderTagList(containerId, listKey);
       // Auto-persist filter item
@@ -283,18 +305,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // 3. Setup Filter Inputs
+  // 3. Interception Toggle Listener
+  const interceptionCheckbox = document.getElementById('options-enable-interception');
+  if (interceptionCheckbox) {
+    interceptionCheckbox.addEventListener('change', (e) => {
+      chrome.storage.local.set({ enableInterception: e.target.checked }, () => {
+        showToast(e.target.checked ? 'Interception enabled ✓' : 'Interception paused ✓', 'success');
+      });
+    });
+  }
+
+  // 4. Setup Filter Inputs
   setupFilterInput('whitelist-url-input', 'add-whitelist-url', 'whitelist-url-tags', 'whitelistUrls', false);
   setupFilterInput('whitelist-ext-input', 'add-whitelist-ext', 'whitelist-ext-tags', 'whitelistExts', true);
   setupFilterInput('blacklist-url-input', 'add-blacklist-url', 'blacklist-url-tags', 'blacklistUrls', false);
   setupFilterInput('blacklist-ext-input', 'add-blacklist-ext', 'blacklist-ext-tags', 'blacklistExts', true);
 
-  // 4. Load from storage
+  // 5. Load from storage
   const defaults = {
     port: 56800,
     token: "",
     theme: "system",
     bdmVersion: "",
+    enableInterception: true,
     whitelistUrls: [],
     whitelistExts: [],
     blacklistUrls: [],
@@ -310,6 +343,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('port').value = port;
     document.getElementById('token').value = items.token || '';
+    if (interceptionCheckbox) {
+      interceptionCheckbox.checked = (items.enableInterception !== false);
+    }
 
     applyTheme(items.theme || 'system');
 
@@ -338,7 +374,7 @@ document.addEventListener('DOMContentLoaded', () => {
     testConnection(port, items.token || '');
   });
 
-  // 5. Button Listeners
+  // 6. Button Listeners
   document.getElementById('refresh-btn').addEventListener('click', () => {
     const port = parseInt(document.getElementById('port').value, 10) || 56800;
     const token = document.getElementById('token').value.trim();
@@ -350,12 +386,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const token = document.getElementById('token').value.trim();
     const selectedRadio = document.querySelector('input[name="theme-radio"]:checked');
     const theme = selectedRadio ? selectedRadio.value : 'system';
+    const enableInterception = interceptionCheckbox ? interceptionCheckbox.checked : true;
 
     const payload = {
       host: "localhost",
       port,
       token,
       theme,
+      enableInterception,
       whitelistUrls: filterLists.whitelistUrls,
       whitelistExts: filterLists.whitelistExts,
       blacklistUrls: filterLists.blacklistUrls,
@@ -384,12 +422,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const selectedRadio = document.querySelector('input[name="theme-radio"]:checked');
         const theme = selectedRadio ? selectedRadio.value : 'system';
+        const enableInterception = interceptionCheckbox ? interceptionCheckbox.checked : true;
 
         const savePayload = {
           host: "localhost",
           port,
           token: token || '',
           theme,
+          enableInterception,
           whitelistUrls: filterLists.whitelistUrls,
           whitelistExts: filterLists.whitelistExts,
           blacklistUrls: filterLists.blacklistUrls,
@@ -418,6 +458,7 @@ document.addEventListener('DOMContentLoaded', () => {
       port: 56800,
       token: "",
       theme: "system",
+      enableInterception: true,
       whitelistUrls: [],
       whitelistExts: [],
       blacklistUrls: [],
@@ -427,6 +468,7 @@ document.addEventListener('DOMContentLoaded', () => {
     chrome.storage.local.set(defaults, () => {
       document.getElementById('port').value = defaults.port;
       document.getElementById('token').value = defaults.token;
+      if (interceptionCheckbox) interceptionCheckbox.checked = true;
       applyTheme(defaults.theme);
 
       filterLists.whitelistUrls = [];

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -201,9 +201,27 @@ body {
 }
 
 .toggle-subtitle {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-top: 2px;
   font-size: 11px;
   color: var(--text-muted);
   word-break: break-all;
+}
+
+.site-domain {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--bdm-highlight);
+  font-family: monospace, var(--font-family);
+  word-break: break-all;
+}
+
+.site-desc {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  line-height: 1.3;
 }
 
 .divider {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -160,3 +160,109 @@ body {
   background-color: var(--bdm-error);
   box-shadow: 0 0 6px rgba(239, 68, 68, 0.4);
 }
+
+/* Controls Card & Toggles */
+.controls-card {
+  margin-top: 12px;
+  background-color: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-row.disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.toggle-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-grow: 1;
+}
+
+.toggle-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.toggle-subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.divider {
+  height: 1px;
+  background-color: var(--border-subtle);
+  margin: 2px 0;
+}
+
+/* Toggle Switch Control */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--border-color);
+  transition: var(--transition);
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: var(--transition);
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: var(--bdm-highlight);
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px var(--bdm-highlight);
+}
+
+input:checked + .slider:before {
+  transform: translateX(16px);
+}
+
+input:disabled + .slider {
+  cursor: not-allowed;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -46,7 +46,10 @@
       <label class="toggle-row" id="site-toggle-row">
         <div class="toggle-info">
           <span class="toggle-title">Don't catch downloads from this site</span>
-          <span class="toggle-subtitle" id="site-subtitle">Checking website...</span>
+          <div class="toggle-subtitle" id="site-subtitle">
+            <span class="site-domain" id="site-domain">Checking website...</span>
+            <span class="site-desc" id="site-desc"></span>
+          </div>
         </div>
         <div class="switch">
           <input type="checkbox" id="toggle-site-interception">

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -45,11 +45,11 @@
       <!-- Current Website Toggle -->
       <label class="toggle-row" id="site-toggle-row">
         <div class="toggle-info">
-          <span class="toggle-title">Catch downloads on this site</span>
+          <span class="toggle-title">Don't catch downloads from this site</span>
           <span class="toggle-subtitle" id="site-subtitle">Checking website...</span>
         </div>
         <div class="switch">
-          <input type="checkbox" id="toggle-site-interception" checked>
+          <input type="checkbox" id="toggle-site-interception">
           <span class="slider"></span>
         </div>
       </label>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -32,7 +32,7 @@
       <label class="toggle-row" id="global-toggle-row">
         <div class="toggle-info">
           <span class="toggle-title">Capture downloads from all sites</span>
-          <span class="toggle-subtitle" id="global-subtitle">Automatically intercept browser downloads</span>
+          <span class="toggle-subtitle" id="global-subtitle">Capture downloads browser-wide</span>
         </div>
         <div class="switch">
           <input type="checkbox" id="toggle-global-interception" checked>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -17,12 +17,42 @@
       </a>
     </header>
 
+    <!-- Backend Status Box -->
     <div class="status-box">
       <div id="dot" class="dot"></div>
       <div class="status-info">
         <span class="status-label">Backend Status</span>
         <span id="status-text" class="status-value">Connecting...</span>
       </div>
+    </div>
+
+    <!-- Quick Capture Controls (FDM Style) -->
+    <div class="controls-card">
+      <!-- Master Global Toggle -->
+      <label class="toggle-row" id="global-toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-title">Capture downloads from all sites</span>
+          <span class="toggle-subtitle" id="global-subtitle">Automatically intercept browser downloads</span>
+        </div>
+        <div class="switch">
+          <input type="checkbox" id="toggle-global-interception" checked>
+          <span class="slider"></span>
+        </div>
+      </label>
+
+      <div class="divider"></div>
+
+      <!-- Current Website Toggle -->
+      <label class="toggle-row" id="site-toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-title">Catch downloads on this site</span>
+          <span class="toggle-subtitle" id="site-subtitle">Checking website...</span>
+        </div>
+        <div class="switch">
+          <input type="checkbox" id="toggle-site-interception" checked>
+          <span class="slider"></span>
+        </div>
+      </label>
     </div>
   </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -33,16 +33,15 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () 
   });
 });
 
-// Live storage sync
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName === 'local' && changes.theme) {
-    applyTheme(changes.theme.newValue);
+// Live options link
+document.addEventListener('DOMContentLoaded', () => {
+  const optLink = document.getElementById('options-link');
+  if (optLink) {
+    optLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      chrome.runtime.openOptionsPage();
+    });
   }
-});
-
-document.getElementById('options-link').addEventListener('click', (e) => {
-  e.preventDefault();
-  chrome.runtime.openOptionsPage();
 });
 
 async function checkAria2(port, token) {
@@ -77,8 +76,148 @@ async function checkAria2(port, token) {
   }
 }
 
-chrome.storage.local.get({ theme: "system", port: 56800, token: "", bdmVersion: "" }, async (items) => {
+function extractHostname(url) {
+  if (!url || typeof url !== 'string') return "";
+  if (!url.startsWith('http://') && !url.startsWith('https://')) return "";
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.toLowerCase();
+  } catch (e) {
+    return "";
+  }
+}
+
+let currentDomain = "";
+
+function updateGlobalToggleUI(enabled) {
+  const toggle = document.getElementById('toggle-global-interception');
+  const subtitle = document.getElementById('global-subtitle');
+  if (toggle) toggle.checked = enabled;
+  if (subtitle) {
+    subtitle.textContent = enabled 
+      ? "Automatically intercept browser downloads" 
+      : "Interception paused for all websites";
+  }
+}
+
+function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
+  const toggle = document.getElementById('toggle-site-interception');
+  const subtitle = document.getElementById('site-subtitle');
+  const row = document.getElementById('site-toggle-row');
+
+  if (!hasValidSite || !domain) {
+    if (toggle) {
+      toggle.checked = false;
+      toggle.disabled = true;
+    }
+    if (subtitle) subtitle.textContent = "No active website";
+    if (row) row.classList.add('disabled');
+    return;
+  }
+
+  if (row) row.classList.remove('disabled');
+  if (toggle) {
+    toggle.disabled = false;
+    toggle.checked = !isBlacklisted;
+  }
+  if (subtitle) {
+    subtitle.textContent = isBlacklisted 
+      ? `Bypassed on ${domain} (Browser handles downloads)` 
+      : `Active on ${domain}`;
+  }
+}
+
+// Live storage sync
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === 'local') {
+    if (changes.theme) {
+      applyTheme(changes.theme.newValue);
+    }
+    if (changes.enableInterception !== undefined) {
+      updateGlobalToggleUI(changes.enableInterception.newValue);
+    }
+    if (changes.blacklistUrls && currentDomain) {
+      const bList = Array.isArray(changes.blacklistUrls.newValue) ? changes.blacklistUrls.newValue : [];
+      const isBlacklisted = bList.some(p => {
+        const clean = p.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
+        return clean === currentDomain || currentDomain.endsWith('.' + clean);
+      });
+      updateSiteToggleUI(currentDomain, isBlacklisted, true);
+    }
+  }
+});
+
+// Setup Toggle Listeners
+document.getElementById('toggle-global-interception').addEventListener('change', (e) => {
+  const enabled = e.target.checked;
+  chrome.storage.local.set({ enableInterception: enabled }, () => {
+    updateGlobalToggleUI(enabled);
+  });
+});
+
+document.getElementById('toggle-site-interception').addEventListener('change', (e) => {
+  const catchOnSite = e.target.checked;
+  if (!currentDomain) return;
+
+  chrome.storage.local.get({ blacklistUrls: [] }, (items) => {
+    let list = Array.isArray(items.blacklistUrls) ? [...items.blacklistUrls] : [];
+
+    if (!catchOnSite) {
+      // Add domain to blacklist if not already present
+      const alreadyIn = list.some(p => {
+        const clean = p.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
+        return clean === currentDomain;
+      });
+      if (!alreadyIn) {
+        list.push(currentDomain);
+      }
+    } else {
+      // Remove domain and its variations from blacklist
+      list = list.filter(p => {
+        const clean = p.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
+        return clean !== currentDomain && !currentDomain.endsWith('.' + clean);
+      });
+    }
+
+    chrome.storage.local.set({ blacklistUrls: list }, () => {
+      updateSiteToggleUI(currentDomain, !catchOnSite, true);
+    });
+  });
+});
+
+chrome.storage.local.get({
+  theme: "system",
+  port: 56800,
+  token: "",
+  bdmVersion: "",
+  enableInterception: true,
+  blacklistUrls: []
+}, async (items) => {
   applyTheme(items.theme || "system");
+  updateGlobalToggleUI(items.enableInterception !== false);
+
+  // Detect active tab domain
+  try {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tabs && tabs.length > 0 && tabs[0].url) {
+      const domain = extractHostname(tabs[0].url);
+      if (domain) {
+        currentDomain = domain;
+        const bList = Array.isArray(items.blacklistUrls) ? items.blacklistUrls : [];
+        const isBlacklisted = bList.some(p => {
+          const clean = p.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
+          return clean === domain || domain.endsWith('.' + clean);
+        });
+        updateSiteToggleUI(domain, isBlacklisted, true);
+      } else {
+        updateSiteToggleUI("", false, false);
+      }
+    } else {
+      updateSiteToggleUI("", false, false);
+    }
+  } catch (e) {
+    updateSiteToggleUI("", false, false);
+  }
 
   const statusText = document.getElementById('status-text');
   const dot = document.getElementById('dot');

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -118,12 +118,12 @@ function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
   if (row) row.classList.remove('disabled');
   if (toggle) {
     toggle.disabled = false;
-    toggle.checked = !isBlacklisted;
+    toggle.checked = isBlacklisted; // Checked = Don't catch (bypassed)
   }
   if (subtitle) {
     subtitle.textContent = isBlacklisted 
-      ? `Bypassed on ${domain} (Browser handles downloads)` 
-      : `Active on ${domain}`;
+      ? `Bypassed on ${domain} (Browser downloads directly)` 
+      : `Active on ${domain} (Bengal DM catches downloads)`;
   }
 }
 
@@ -156,13 +156,13 @@ document.getElementById('toggle-global-interception').addEventListener('change',
 });
 
 document.getElementById('toggle-site-interception').addEventListener('change', (e) => {
-  const catchOnSite = e.target.checked;
+  const bypassThisSite = e.target.checked;
   if (!currentDomain) return;
 
   chrome.storage.local.get({ blacklistUrls: [] }, (items) => {
     let list = Array.isArray(items.blacklistUrls) ? [...items.blacklistUrls] : [];
 
-    if (!catchOnSite) {
+    if (bypassThisSite) {
       // Add domain to blacklist if not already present
       const alreadyIn = list.some(p => {
         const clean = p.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
@@ -180,7 +180,7 @@ document.getElementById('toggle-site-interception').addEventListener('change', (
     }
 
     chrome.storage.local.set({ blacklistUrls: list }, () => {
-      updateSiteToggleUI(currentDomain, !catchOnSite, true);
+      updateSiteToggleUI(currentDomain, bypassThisSite, true);
     });
   });
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,7 +102,8 @@ function updateGlobalToggleUI(enabled) {
 
 function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
   const toggle = document.getElementById('toggle-site-interception');
-  const subtitle = document.getElementById('site-subtitle');
+  const domainElem = document.getElementById('site-domain');
+  const descElem = document.getElementById('site-desc');
   const row = document.getElementById('site-toggle-row');
 
   if (!hasValidSite || !domain) {
@@ -110,7 +111,8 @@ function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
       toggle.checked = false;
       toggle.disabled = true;
     }
-    if (subtitle) subtitle.textContent = "No active website";
+    if (domainElem) domainElem.textContent = "No active website";
+    if (descElem) descElem.textContent = "Open a webpage to configure per-site rules";
     if (row) row.classList.add('disabled');
     return;
   }
@@ -120,10 +122,13 @@ function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
     toggle.disabled = false;
     toggle.checked = isBlacklisted; // Checked = Don't catch (bypassed)
   }
-  if (subtitle) {
-    subtitle.textContent = isBlacklisted 
-      ? `Bypassed on ${domain} (Browser downloads directly)` 
-      : `Active on ${domain} (Bengal DM catches downloads)`;
+  if (domainElem) {
+    domainElem.textContent = domain;
+  }
+  if (descElem) {
+    descElem.textContent = isBlacklisted 
+      ? "Bypassed — downloads are handled directly by your browser" 
+      : "Active — Bengal DM captures downloads from this site";
   }
 }
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -95,8 +95,8 @@ function updateGlobalToggleUI(enabled) {
   if (toggle) toggle.checked = enabled;
   if (subtitle) {
     subtitle.textContent = enabled 
-      ? "Automatically intercept browser downloads" 
-      : "Interception paused for all websites";
+      ? "Capture downloads browser-wide" 
+      : "Paused for all websites";
   }
 }
 
@@ -112,7 +112,7 @@ function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
       toggle.disabled = true;
     }
     if (domainElem) domainElem.textContent = "No active website";
-    if (descElem) descElem.textContent = "Open a webpage to configure per-site rules";
+    if (descElem) descElem.textContent = "Open a website to configure";
     if (row) row.classList.add('disabled');
     return;
   }
@@ -127,8 +127,8 @@ function updateSiteToggleUI(domain, isBlacklisted, hasValidSite) {
   }
   if (descElem) {
     descElem.textContent = isBlacklisted 
-      ? "Bypassed — downloads are handled directly by your browser" 
-      : "Active — Bengal DM captures downloads from this site";
+      ? "Handled by browser" 
+      : "Captured by Bengal DM";
   }
 }
 

--- a/scripts/pack_extension.py
+++ b/scripts/pack_extension.py
@@ -37,6 +37,8 @@ def build_zip_package(extension_dir, output_zip, target="generic"):
                     if target == "chrome":
                         if "background" in manifest and "scripts" in manifest["background"]:
                             manifest["background"].pop("scripts", None)
+                        if "permissions" in manifest and "webRequestBlocking" in manifest["permissions"]:
+                            manifest["permissions"].remove("webRequestBlocking")
                     elif target == "firefox":
                         if "background" in manifest and "service_worker" in manifest["background"]:
                             manifest["background"].pop("service_worker", None)


### PR DESCRIPTION
## Summary
- **Manifest Version:** Updated extension manifest version to `0.3`.
- **Firefox MV3 Network Layer Blocking:** Added `webRequestBlocking` permission to intercept and synchronously cancel download streams in `onHeadersReceived`, stopping downloads before Firefox instantiates the download subsystem.
- **Chrome MV3 Pre-UI Pipeline Cancellation:** Hooked `downloads.onDeterminingFilename` (suppresses Save-As dialog & UI animation) and `downloads.onChanged` (immediately invokes `downloads.erase({ id })` on `interrupted` state).
- **Site Compatibility:** Fully preserves website countdown timers and waiting landing pages (e.g. VLC VideoLAN, SourceForge, Mega, MediaFire).
- **Automated Packaging:** Updated `scripts/pack_extension.py` to package clean Chrome and Firefox MV3 bundles.