### PR TITLE
fix(snap): aria2c stops immediately — LD_LIBRARY_PATH stripped by get_clean_env()

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -578,9 +578,15 @@ def get_clean_env(extra_paths=None):
                 if "_MEI" in part or "_mei" in part:
                     mei_dirs.add(os.path.abspath(part))
 
-    # 2. Hard clear PyInstaller, loader, and Qt specific environment keys
+    # 2. Hard clear PyInstaller, loader, and Qt specific environment keys.
+    # Exception: inside a snap, LD_LIBRARY_PATH contains only $SNAP/… paths (set by
+    # snapd and the GNOME extension). aria2c and other snap-packaged binaries are
+    # dynamically linked against these snap-internal libs (libaria2.so.0, libstdc++,
+    # etc.) and will exit with code 127 if LD_LIBRARY_PATH is stripped.
+    # The step-4 MEI-path scrub below still removes any stray _MEI entries.
+    _in_snap = bool(os.environ.get("SNAP"))
     keys_to_clear = [
-        "LD_LIBRARY_PATH", "LD_LIBRARY_PATH_ORIG", "ORIG_LD_LIBRARY_PATH",
+        *([] if _in_snap else ["LD_LIBRARY_PATH", "LD_LIBRARY_PATH_ORIG", "ORIG_LD_LIBRARY_PATH"]),
         "LD_PRELOAD", "LD_AUDIT",
         "DYLD_LIBRARY_PATH", "DYLD_LIBRARY_PATH_ORIG", "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
         "QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH", "QML_IMPORT_PATH", "QML2_IMPORT_PATH",

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -260,21 +260,6 @@ class MainWindow(QMainWindow):
             token = ext_data.get("token", "")
             max_conn = str(ext_data.get("max_connections", 8))
 
-            # If an Aria2 instance is already responding on this port, synchronize proxy options and return
-            try:
-                import socket
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.settimeout(0.2)
-                    if s.connect_ex(("127.0.0.1", port)) == 0:
-                        # Existing daemon is already active on the port - synchronize proxy setting
-                        try:
-                            from core.utils import call_aria2_rpc
-                            call_aria2_rpc("aria2.changeGlobalOption", [{"all-proxy": get_aria2_proxy_url()}], port=port, token=token)
-                        except Exception:
-                            pass
-                        return None
-            except Exception:
-                pass
 
             # Note: --no-proxy is not needed for the server side of RPC
             cmd = [


### PR DESCRIPTION
## Root Causes

### Bug 1 — aria2c exits with code 127

`get_clean_env()` unconditionally cleared `LD_LIBRARY_PATH`. The snap-packaged `aria2c` is a dynamically linked ELF that requires snap-internal shared libraries:

```
libaria2.so.0  → $SNAP/usr/lib/x86_64-linux-gnu/
libstdc++.so.6 → $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/
libgnutls.so.30 → $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/
```

Without `LD_LIBRARY_PATH`, aria2c exited immediately with:
```
error while loading shared libraries: libaria2.so.0: cannot open shared object file
```
→ Status bar permanently showed **Aria2: Stopped**.

**Fix:** Skip clearing `LD_LIBRARY_PATH` when `$SNAP` is set. The snap's `LD_LIBRARY_PATH` only contains `$SNAP/…` paths — never PyInstaller `_MEI` dirs — so preserving it is safe. The step-4 MEI scrub still runs.

**Verified in live snap shell:**
| | Result |
|---|---|
| Before (stripped) | `returncode=127`, `libaria2.so.0 not found` |
| After (preserved) | `returncode=None` (running), RPC port open ✅ |

---

### Bug 2 — Snap silently connects to a foreign aria2 daemon

`start_aria2_daemon()` had a port-check early-exit:

```python
if s.connect_ex(("127.0.0.1", port)) == 0:
    return None   # exits if ANY process holds port 56800
```

If an AppImage instance's aria2 was already on port 56800, snap returned `None` and owned no process handle. The status bar detected the open port and showed **Connected** — to the AppImage's daemon. When the AppImage closed, the snap showed **Stopped** unexpectedly.

**Fix:** Remove the early-exit entirely. Each app instance always launches its own aria2c. Port conflicts are handled by aria2c failing to bind (logged to `DEVNULL`).

---

## Testing

- ✅ 166/166 tests pass
- ✅ Live snap shell: aria2c starts, RPC port opens correctly after fix