### PR TITLE
fix(ui,core): resolve snap downloads directory and preserve options dialog states

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,52 +1,84 @@
 import os
+import re
 import json
-from .utils import get_config_dir, get_cache_dir
+from .utils import get_config_dir, get_cache_dir, get_user_downloads_dir, get_user_home_dir
 
-DEFAULT_CATEGORIES = {
-    "General": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads"),
-        "extensions": "plj"
-    },
-    "Compressed": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Compressed"),
-        "extensions": "7z ace arj bz2 gz gzip lzh rar sea sit sitx tar zip xz bz bz2 lzma war ear"
-    },
-    "Documents": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Documents"),
-        "extensions": "pdf pps ppt doc docx xls xlsx pptx odt ods odp rtf csv ppsx dot"
-    },
-    "Music": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Music"),
-        "extensions": "aac aif m4a mp3 mpa ogg wav wma"
-    },
-    "Programs": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Programs"),
-        "extensions": "exe msi msu bin deb rpm appimage flatpak snap apk sh bat cmd run dmg pkg jar"
-    },
-    "Video": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Video"),
-        "extensions": "3gp asf avi m4v mkv mov mp4 mpe mpeg mpg ogv rmvb wmv"
-    },
-    "Disk Images": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Images"),
-        "extensions": "img iso"
-    },
-    "Images": {
-        "path": os.path.join(os.path.expanduser("~"), "Downloads", "Pictures"),
-        "extensions": "tif tiff"
+def get_default_categories():
+    downloads = get_user_downloads_dir()
+    return {
+        "General": {
+            "path": downloads,
+            "extensions": "plj"
+        },
+        "Compressed": {
+            "path": os.path.join(downloads, "Compressed"),
+            "extensions": "7z ace arj bz2 gz gzip lzh rar sea sit sitx tar zip xz bz bz2 lzma war ear"
+        },
+        "Documents": {
+            "path": os.path.join(downloads, "Documents"),
+            "extensions": "pdf pps ppt doc docx xls xlsx pptx odt ods odp rtf csv ppsx dot"
+        },
+        "Music": {
+            "path": os.path.join(downloads, "Music"),
+            "extensions": "aac aif m4a mp3 mpa ogg wav wma"
+        },
+        "Programs": {
+            "path": os.path.join(downloads, "Programs"),
+            "extensions": "exe msi msu bin deb rpm appimage flatpak snap apk sh bat cmd run dmg pkg jar"
+        },
+        "Video": {
+            "path": os.path.join(downloads, "Video"),
+            "extensions": "3gp asf avi m4v mkv mov mp4 mpe mpeg mpg ogv rmvb wmv"
+        },
+        "Disk Images": {
+            "path": os.path.join(downloads, "Images"),
+            "extensions": "img iso"
+        },
+        "Images": {
+            "path": os.path.join(downloads, "Pictures"),
+            "extensions": "tif tiff"
+        }
     }
-}
+
+DEFAULT_CATEGORIES = get_default_categories()
+
+def _normalize_snap_path(path: str) -> str:
+    """Normalize snap internal download path to real user download path if running in Snap or migrated."""
+    if not path or not isinstance(path, str):
+        return path
+
+    snap_user_data = os.environ.get("SNAP_USER_DATA")
+    real_home = os.environ.get("SNAP_REAL_HOME")
+    if snap_user_data and real_home and path.startswith(snap_user_data):
+        rel = os.path.relpath(path, snap_user_data)
+        return os.path.normpath(os.path.join(real_home, rel))
+
+    # Pattern for snap user paths: /home/<user>/snap/<snap_name>/<rev>/Downloads...
+    m = re.match(r"^/home/[^/]+/snap/[^/]+/[^/]+/Downloads(/.*)?$", path)
+    if m:
+        downloads_base = get_user_downloads_dir()
+        sub = m.group(1) or ""
+        sub = sub.lstrip("/")
+        return os.path.join(downloads_base, sub) if sub else downloads_base
+
+    return path
 
 def load_category_config():
     path = os.path.join(get_config_dir(), "categories.json")
-    data = {"categories": DEFAULT_CATEGORIES, "temp_dir": os.path.join(get_cache_dir(), "downloads")}
+    defaults = get_default_categories()
+    data = {"categories": defaults, "temp_dir": os.path.join(get_cache_dir(), "downloads")}
     if os.path.exists(path):
         try:
             with open(path, "r") as f:
                 loaded = json.load(f)
-                for cat, defaults in DEFAULT_CATEGORIES.items():
+                if "categories" not in loaded or not isinstance(loaded["categories"], dict):
+                    loaded["categories"] = {}
+                for cat, default_val in defaults.items():
                     if cat not in loaded["categories"]:
-                        loaded["categories"][cat] = defaults
+                        loaded["categories"][cat] = default_val
+                    else:
+                        cat_path = loaded["categories"][cat].get("path", "")
+                        loaded["categories"][cat]["path"] = _normalize_snap_path(cat_path)
                 return loaded
         except:
             pass

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -251,6 +251,47 @@ def get_unique_filepath(filepath, existing_paths=None, existing_names=None, forc
     return os.path.join(base_dir, candidate_name)
 
 
+def get_user_home_dir() -> str:
+    """
+    Returns the real host user home directory.
+    Under Snap confinement, $HOME points to $SNAP_USER_DATA (/home/<user>/snap/<snap>/<rev>).
+    $SNAP_REAL_HOME contains the real host user home directory (/home/<user>).
+    """
+    real_home = os.environ.get("SNAP_REAL_HOME")
+    if real_home and os.path.isdir(real_home):
+        return real_home
+    return os.path.expanduser("~")
+
+
+def get_user_downloads_dir() -> str:
+    """
+    Returns the user's default Downloads directory.
+    Checks XDG user dirs (~/.config/user-dirs.dirs) with real home support for Snap/Flatpak,
+    falling back to ~/Downloads under the real user home.
+    """
+    home = get_user_home_dir()
+
+    # 1. Check XDG user-dirs configuration in user's real home
+    user_dirs_file = os.path.join(home, ".config", "user-dirs.dirs")
+    if os.path.isfile(user_dirs_file):
+        try:
+            with open(user_dirs_file, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("XDG_DOWNLOAD_DIR"):
+                        parts = line.split("=", 1)
+                        if len(parts) == 2:
+                            val = parts[1].strip().strip('"').strip("'")
+                            val = val.replace("$HOME", home).replace("${HOME}", home)
+                            if val:
+                                return os.path.abspath(val)
+        except Exception:
+            pass
+
+    # 2. Fallback to ~/Downloads under real home
+    return os.path.join(home, "Downloads")
+
+
 def get_data_dir():
     home = os.path.expanduser("~")
     base = os.environ.get('XDG_DATA_HOME') or os.path.join(home, '.local', 'share')

--- a/src/ui/dialogs/file_info.py
+++ b/src/ui/dialogs/file_info.py
@@ -5,7 +5,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QFont
 from PyQt6.QtCore import Qt
-from core.utils import get_unique_filepath, choose_portal_save_path
+from core.utils import get_unique_filepath, choose_portal_save_path, get_user_downloads_dir
 from core.config import load_category_config
 from core.memory_guard import MemoryGuard
 
@@ -136,7 +136,7 @@ class DownloadFileInfoDialog(QDialog):
         if cat in categories:
             base_dir = categories[cat]["path"]
         else:
-            base_dir = os.path.join(os.path.expanduser("~"), "Downloads")
+            base_dir = get_user_downloads_dir()
         
         try: os.makedirs(base_dir, exist_ok=True)
         except: pass
@@ -155,7 +155,7 @@ class DownloadFileInfoDialog(QDialog):
         
     def browse_save_path(self):
         current_text = self.save_input.text().strip()
-        folder = os.path.dirname(current_text) if current_text else os.path.expanduser("~/Downloads")
+        folder = os.path.dirname(current_text) if current_text else get_user_downloads_dir()
         filename = os.path.basename(current_text) if current_text else self.file_info.get("filename", "")
         path = choose_portal_save_path("Save File As", filename, folder)
         if path:

--- a/src/ui/dialogs/media_downloader.py
+++ b/src/ui/dialogs/media_downloader.py
@@ -983,14 +983,14 @@ class MediaDownloaderDialog(QDialog):
             self.lbl_cookies_status.setStyleSheet("font-size: 11px; color: #e5a50a;")
 
     def _on_browse_cookies_clicked(self):
-        from core.utils import choose_portal_open_file_path
+        from core.utils import choose_portal_open_file_path, get_user_home_dir
 
-        file_path = choose_portal_open_file_path(title="Select Cookies File", folder=os.path.expanduser("~"))
+        file_path = choose_portal_open_file_path(title="Select Cookies File", folder=get_user_home_dir())
         if file_path is None:
             file_path, _ = QFileDialog.getOpenFileName(
                 self,
                 "Select Cookies File",
-                os.path.expanduser("~"),
+                get_user_home_dir(),
                 "Text Files (*.txt);;All Files (*)"
             )
         if file_path:

--- a/src/ui/dialogs/options.py
+++ b/src/ui/dialogs/options.py
@@ -12,7 +12,7 @@ from core.utils import (
     load_proxy_config, save_proxy_config, get_aria2_proxy_url,
     load_extension_config, save_extension_config, call_aria2_rpc,
     find_aria2, choose_portal_save_path, choose_portal_folder_path, choose_portal_open_file_path,
-    is_autostart_enabled, set_autostart_enabled
+    is_autostart_enabled, set_autostart_enabled, get_user_downloads_dir, get_user_home_dir
 )
 from core.config import load_category_config, save_category_config
 from core.memory_guard import MemoryGuard
@@ -461,10 +461,6 @@ class OptionsDialog(QDialog):
         vbox_dialogs.addWidget(self.chk_show_queue_complete_dialog)
 
         def _on_silent_toggled(checked):
-            if checked:
-                self.chk_show_start_dialog.setChecked(False)
-                self.chk_show_progress_dialog.setChecked(False)
-                self.chk_show_complete_dialog.setChecked(False)
             self.chk_show_start_dialog.setEnabled(not checked)
             self.chk_show_progress_dialog.setEnabled(not checked)
             self.chk_show_complete_dialog.setEnabled(not checked)
@@ -1092,7 +1088,7 @@ class OptionsDialog(QDialog):
 
     def _browse_opt_cookies_file(self):
         current_path = self.txt_opt_cookies_path.text().strip()
-        folder = os.path.dirname(current_path) if (current_path and os.path.exists(current_path)) else os.path.expanduser("~")
+        folder = os.path.dirname(current_path) if (current_path and os.path.exists(current_path)) else get_user_home_dir()
         file_path = choose_portal_open_file_path(title="Select Netscape Cookies File", folder=folder)
         if file_path is None:
             from PyQt6.QtWidgets import QFileDialog
@@ -1199,7 +1195,7 @@ class OptionsDialog(QDialog):
 
     def browse_folder(self, line_edit):
         current_path = line_edit.text().strip()
-        folder = current_path if os.path.exists(current_path) else os.path.expanduser("~/Downloads")
+        folder = current_path if os.path.exists(current_path) else get_user_downloads_dir()
         path = choose_portal_folder_path("Select Directory", folder)
         if path:
             line_edit.setText(path)

--- a/src/ui/dialogs/progress.py
+++ b/src/ui/dialogs/progress.py
@@ -42,7 +42,16 @@ class DownloadProgressDialog(QDialog):
         ext_data = load_extension_config()
         initial_conn = ext_data.get("max_connections", 8)
         self.init_segment_table(int(initial_conn) if isinstance(initial_conn, (int, float, str)) and str(initial_conn).isdigit() else 8)
-        self.worker.start()
+        if hasattr(self.worker, 'isRunning'):
+            if not self.worker.isRunning():
+                self.worker.start()
+        elif hasattr(self.worker, 'start'):
+            self.worker.start()
+
+        tb = getattr(self.worker, 'total_bytes', None)
+        if isinstance(tb, (int, float)) and tb > 0:
+            self.total_bytes = tb
+            self.lbl_size.setText(self.worker.format_bytes(tb, precision=2, pad=False))
 
     def setup_status_tab(self):
         layout = QVBoxLayout(self.status_tab)
@@ -535,6 +544,8 @@ class DownloadProgressDialog(QDialog):
     def closeEvent(self, event):
         if not getattr(self, "is_completed", False):
             if hasattr(self, "worker") and self.worker:
-                self.worker.stop()
-                self.worker.finished_signal.emit(self.worker.row_index, "Paused")
+                if hasattr(self.worker, "stop") and callable(self.worker.stop):
+                    self.worker.stop()
+                if hasattr(self.worker, "finished_signal"):
+                    self.worker.finished_signal.emit(getattr(self.worker, "row_index", 0), "Paused")
         self.reject()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -68,7 +68,8 @@ from core.utils import (
     get_data_dir, get_config_dir, get_unique_filepath, ensure_aria2, 
     load_proxy_config, load_extension_config, get_aria2_proxy_url,
     show_in_folder, resolve_filename, open_file_generic, open_with, choose_portal_save_path,
-    is_media_downloader_url, setup_logging, format_bytes, get_clean_env, get_process_memory
+    is_media_downloader_url, setup_logging, format_bytes, get_clean_env, get_process_memory,
+    get_user_downloads_dir
 )
 from core.memory_guard import MemoryGuard
 
@@ -2661,7 +2662,7 @@ class MainWindow(QMainWindow):
         show_in_folder(path)
 
     def open_downloads_folder_generic(self):
-        path = os.path.join(os.path.expanduser("~"), "Downloads")
+        path = get_user_downloads_dir()
         show_in_folder(path)
 
     def ctx_move(self, item):
@@ -3306,7 +3307,7 @@ class MainWindow(QMainWindow):
         save_dir = custom_save_dir if custom_save_dir else categories[final_category]["path"]
         if not os.path.exists(save_dir):
             try: os.makedirs(save_dir)
-            except: save_dir = os.path.join(os.path.expanduser("~"), "Downloads")
+            except: save_dir = get_user_downloads_dir()
 
         temp_dir = config.get("temp_dir")
 
@@ -4215,7 +4216,7 @@ class MainWindow(QMainWindow):
             try:
                 os.makedirs(save_dir, exist_ok=True)
             except Exception:
-                save_dir = os.path.join(os.path.expanduser("~"), "Downloads")
+                save_dir = get_user_downloads_dir()
 
         from core.utils import sanitize_media_filename, get_unique_media_filepath
         base_name, ext = os.path.splitext(filename)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1317,6 +1317,7 @@ class MainWindow(QMainWindow):
                     if is_active:
                         selection_has_active = True
                         selection_has_pausable = True
+                        selection_has_resumable = True
                     else:
                         selection_has_resumable = True
         
@@ -3469,49 +3470,43 @@ class MainWindow(QMainWindow):
                 item_name = self.download_table.item(row, 0)
                 if not item_name:
                     continue
-                
-                # If already active, bring dialog to front or resume if paused
+                # If already active, bring dialog to front (or create/restore if silent/hidden) and resume if paused
                 key = self._get_item_key(item_name)
-                if key in self.active_downloads:
-                    dialog = self.active_downloads[key]
-                    if not MemoryGuard.is_widget_alive(dialog) and not hasattr(dialog, 'isRunning'):
-                        self.active_downloads.pop(key, None)
-                        dialog = None
-
+                if key in self.active_downloads or self._is_download_active(item_name):
+                    dialog = self.show_download_progress_dialog(item_name)
+                    status_item = self.download_table.item(row, 2)
+                    logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
+                    
+                    worker = None
                     if dialog:
-                        status_item = self.download_table.item(row, 2)
-                        logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
-                        
-                        worker = getattr(dialog, 'worker', dialog)
-                        if worker and (getattr(worker, 'is_paused', False) or getattr(worker, 'is_pause_requested', False) or logic_status in ["Paused", "Cancelled", "Error"]):
-                            gen = (item_name.data(Qt.ItemDataRole.UserRole + 13) or 0) + 1
-                            item_name.setData(Qt.ItemDataRole.UserRole + 13, gen)
-                            item_name.setData(Qt.ItemDataRole.UserRole + 11, "Normal")
-                            worker.generation = gen
-                            # Forward resume to existing worker
-                            try:
-                                if hasattr(worker, 'resume'):
-                                    worker.resume()
-                            except (RuntimeError, Exception):
-                                pass
-                            if hasattr(dialog, 'lbl_main_status'):
-                                try:
-                                    dialog.lbl_main_status.setText("Resuming...")
-                                    dialog.btn_pause.setText("Pause")
-                                    dialog.btn_cancel.setText("Cancel")
-                                except Exception:
-                                    pass
-                            self._set_status_text(row, "Resuming...", logic_status="Resuming...")
-                            if status_item:
-                                status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
-                            self._set_row_bold(row, True)
-                        
+                        worker = getattr(dialog, 'worker', None)
+                    elif key in self.active_downloads:
+                        entry = self.active_downloads[key]
+                        worker = getattr(entry, 'worker', entry)
+
+                    if worker and (getattr(worker, 'is_paused', False) or getattr(worker, 'is_pause_requested', False) or logic_status in ["Paused", "Cancelled", "Error"]):
+                        gen = (item_name.data(Qt.ItemDataRole.UserRole + 13) or 0) + 1
+                        item_name.setData(Qt.ItemDataRole.UserRole + 13, gen)
+                        item_name.setData(Qt.ItemDataRole.UserRole + 11, "Normal")
+                        worker.generation = gen
+                        # Forward resume to existing worker
                         try:
-                            dialog.activateWindow()
-                            dialog.raise_()
+                            if hasattr(worker, 'resume'):
+                                worker.resume()
                         except (RuntimeError, Exception):
                             pass
-                        continue
+                        if dialog and hasattr(dialog, 'lbl_main_status'):
+                            try:
+                                dialog.lbl_main_status.setText("Resuming...")
+                                dialog.btn_pause.setText("Pause")
+                                dialog.btn_cancel.setText("Cancel")
+                            except Exception:
+                                pass
+                        self._set_status_text(row, "Resuming...", logic_status="Resuming...")
+                        if status_item:
+                            status_item.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
+                        self._set_row_bold(row, True)
+                    continue
                 
                 # Start/Resume download
                 url = item_name.data(Qt.ItemDataRole.UserRole)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -847,6 +847,7 @@ class MainWindow(QMainWindow):
         
         self.download_table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.download_table.customContextMenuRequested.connect(self.show_context_menu)
+        self.download_table.cellDoubleClicked.connect(self._on_table_cell_double_clicked)
         
         header_labels_info = [
             ("File Name", "Name of the downloaded file"),
@@ -1110,23 +1111,12 @@ class MainWindow(QMainWindow):
             if icon.isNull():
                 icon = self.style().standardIcon(QStyle.StandardPixmap.SP_DriveNetIcon)
             self.tray_icon.setIcon(icon)        
-            # Create tray menu
-            tray_menu = QMenu(self)
-            
-            # Show/Hide Action
-            self.action_tray_toggle = QAction("Hide", self) # Default to Hide as window starts visible
-            self.action_tray_toggle.setIcon(get_themed_icon("show_hide"))
-            self.action_tray_toggle.triggered.connect(self.toggle_window)
-            
-            tray_menu.addAction(self.action_tray_toggle)
-            tray_menu.addSeparator()
-            tray_menu.addAction(self.action_add_url)
-            tray_menu.addAction(self.action_media_downloader)
-            tray_menu.addAction(self.action_options)
-            tray_menu.addSeparator()
-            tray_menu.addAction(self.action_exit)
-            
-            self.tray_icon.setContextMenu(tray_menu)
+            # Create dynamic tray menu
+            self.tray_menu = QMenu(self)
+            self.tray_menu.aboutToShow.connect(self._rebuild_tray_menu)
+            self._rebuild_tray_menu()
+
+            self.tray_icon.setContextMenu(self.tray_menu)
             self.tray_icon.setToolTip("Bengal Download Manager")
             self.tray_icon.show()
             
@@ -1136,9 +1126,134 @@ class MainWindow(QMainWindow):
             print(f"Warning: System tray icon initialization failed ({e})")
             self.tray_icon = None
 
+    def _find_row_by_key(self, key):
+        """Finds table row index corresponding to a persistent item key."""
+        if not key or not hasattr(self, "download_table"):
+            return -1
+        for r in range(self.download_table.rowCount()):
+            item_0 = self.download_table.item(r, 0)
+            if item_0 and self._get_item_key(item_0) == key:
+                return r
+        return -1
+
+    def show_download_progress_dialog(self, target):
+        """
+        Brings the DownloadProgressDialog for an active download to the foreground.
+        Creates and connects the dialog on-the-fly if running in headless/silent mode.
+        """
+        key = None
+        if isinstance(target, str):
+            key = target
+        elif isinstance(target, int):
+            row = target
+            if 0 <= row < self.download_table.rowCount():
+                item_ref = self.download_table.item(row, 0)
+                if item_ref:
+                    key = self._get_item_key(item_ref)
+        elif isinstance(target, QTableWidgetItem):
+            key = self._get_item_key(target)
+
+        if not key or key not in getattr(self, "active_downloads", {}):
+            return None
+
+        entry = self.active_downloads[key]
+        dialog = None
+        if isinstance(entry, DownloadProgressDialog) and MemoryGuard.is_widget_alive(entry):
+            dialog = entry
+        else:
+            worker = getattr(entry, "worker", entry)
+            if worker:
+                dialog = DownloadProgressDialog(worker, None)
+                dialog.finished.connect(self.refresh_toolbar_state_on_dialog_close)
+                dialog.finished.connect(lambda *_, k=key: self.active_downloads.pop(k, None))
+                dialog.finished.connect(self._try_start_queued)
+                self.active_downloads[key] = dialog
+
+        if dialog and MemoryGuard.is_widget_alive(dialog):
+            if dialog.isMinimized():
+                dialog.setWindowState(dialog.windowState() & ~Qt.WindowState.WindowMinimized | Qt.WindowState.WindowActive)
+            dialog.show()
+            dialog.showNormal()
+            dialog.raise_()
+            dialog.activateWindow()
+            return dialog
+        return None
+
+    def show_all_active_progress_dialogs(self):
+        """Brings all active download progress dialogs to the front."""
+        active_keys = list(getattr(self, "active_downloads", {}).keys())
+        for key in active_keys:
+            self.show_download_progress_dialog(key)
+
+    def _rebuild_tray_menu(self):
+        """Dynamically populates the system tray context menu with active downloads and actions."""
+        if not hasattr(self, "tray_menu") or self.tray_menu is None:
+            return
+
+        self.tray_menu.clear()
+
+        # 1. Active Downloads Section
+        active_entries = []
+        for key in list(getattr(self, "active_downloads", {}).keys()):
+            row = self._find_row_by_key(key)
+            if row >= 0:
+                item_0 = self.download_table.item(row, 0)
+                if item_0 and self._is_download_active(item_0):
+                    filename = item_0.text()
+                    status_item = self.download_table.item(row, 2)
+                    speed_item = self.download_table.item(row, 4)
+                    status_str = status_item.text() if status_item else ""
+                    speed_str = speed_item.text() if speed_item else ""
+                    active_entries.append((key, filename, status_str, speed_str))
+
+        if active_entries:
+            for key, filename, status_str, speed_str in active_entries:
+                display_name = filename if len(filename) <= 30 else (filename[:27] + "...")
+                desc_parts = []
+                if status_str and status_str not in ["Downloading", "Running"]:
+                    desc_parts.append(status_str)
+                if speed_str and speed_str not in ["0 B/s", "0.00 B/s"]:
+                    desc_parts.append(speed_str)
+                suffix = f" ({' — '.join(desc_parts)})" if desc_parts else ""
+                
+                label = f"{display_name}{suffix}"
+                act = QAction(get_themed_icon("resume"), label, self)
+                act.setToolTip(f"Bring progress window to front: {filename}")
+                act.triggered.connect(lambda _, k=key: self.show_download_progress_dialog(k))
+                self.tray_menu.addAction(act)
+
+            if len(active_entries) > 1:
+                act_all = QAction(get_themed_icon("show_hide"), "Show All Active Downloads", self)
+                act_all.triggered.connect(self.show_all_active_progress_dialogs)
+                self.tray_menu.addAction(act_all)
+
+            self.tray_menu.addSeparator()
+
+        # 2. Main Window Show/Hide Toggle
+        if not hasattr(self, "action_tray_toggle") or self.action_tray_toggle is None:
+            self.action_tray_toggle = QAction("Hide", self)
+            self.action_tray_toggle.setIcon(get_themed_icon("show_hide"))
+            self.action_tray_toggle.triggered.connect(self.toggle_window)
+        self.update_tray_action()
+        self.tray_menu.addAction(self.action_tray_toggle)
+
+        self.tray_menu.addSeparator()
+        self.tray_menu.addAction(self.action_add_url)
+        self.tray_menu.addAction(self.action_media_downloader)
+        self.tray_menu.addAction(self.action_options)
+        self.tray_menu.addSeparator()
+        self.tray_menu.addAction(self.action_exit)
+
     def on_tray_icon_activated(self, reason):
         if reason in (QSystemTrayIcon.ActivationReason.Trigger, QSystemTrayIcon.ActivationReason.DoubleClick):
-            self.toggle_window()
+            if not self.isVisible() or self.isMinimized():
+                self.restore_window()
+                self.show_all_active_progress_dialogs()
+            else:
+                if getattr(self, "active_downloads", {}):
+                    self.show_all_active_progress_dialogs()
+                else:
+                    self.toggle_window()
 
     def restore_window(self):
         """Restores the window from minimized or hidden state and brings it to the foreground."""
@@ -2528,6 +2643,30 @@ class MainWindow(QMainWindow):
             self.download_table.setColumnHidden(logical_idx, not col["visible"])
             self.download_table.setColumnWidth(logical_idx, col["width"])
 
+    def _on_table_cell_double_clicked(self, row: int, column: int):
+        """Restores progress dialog on double click if download is active, or opens file if complete."""
+        if row < 0 or row >= self.download_table.rowCount():
+            return
+        item_0 = self.download_table.item(row, 0)
+        if not item_0:
+            return
+
+        if self._is_download_active(item_0):
+            self.show_download_progress_dialog(item_0)
+        else:
+            status_item = self.download_table.item(row, 2)
+            logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else ""
+            status_text = status_item.text() if status_item else ""
+            is_completed = (logic_status in ["Complete", "Finished"] or status_text in ["Complete", "Finished"] or (item_0.data(Qt.ItemDataRole.UserRole + 11) == "Complete"))
+            if is_completed:
+                path = item_0.data(Qt.ItemDataRole.UserRole + 1)
+                if path and os.path.exists(path):
+                    open_file_generic(path)
+                else:
+                    self.ctx_properties(item_0)
+            elif logic_status in ["Paused", "Cancelled", "Error"]:
+                self.resume_selected_download()
+
     def show_context_menu(self, pos):
         item = self.download_table.itemAt(pos)
         if not item: return
@@ -2574,8 +2713,12 @@ class MainWindow(QMainWindow):
         act_resume = QAction(_fi(get_themed_icon("resume")), "Resume download", self)
         act_resume.triggered.connect(self.resume_selected_download)
         act_resume.setEnabled(is_resumable)
+
+        act_show_progress = QAction(_fi(get_themed_icon("resume")), "Show progress window", self)
+        act_show_progress.triggered.connect(lambda _, it=item_0: self.show_download_progress_dialog(it))
+        act_show_progress.setEnabled(is_active)
         
-        menu.addActions([act_resume, act_stop])
+        menu.addActions([act_resume, act_stop, act_show_progress])
         menu.addSeparator()
 
         act_redownload = QAction(get_themed_icon("unfinished"), "Redownload", self)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1305,25 +1305,23 @@ class MainWindow(QMainWindow):
                 
                 status_item = self.download_table.item(r, 2)
                 logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else None
-                status_text = status_item.text() if status_item else ""
-                status = logic_status if logic_status else status_text
+                status = logic_status if logic_status else (status_item.text() if status_item else "")
                 
                 is_active = self._is_download_active(item)
                 if is_active:
                     selection_has_active = True
                 
                 is_complete = status in ["Complete", "Finished"] or (item.data(Qt.ItemDataRole.UserRole + 11) == "Complete")
-                is_resuming = logic_status == "Resuming..." or status == "Resuming..." or status_text == "Resuming..."
+                is_resuming_or_connecting = logic_status in ["Resuming...", "Starting...", "Pending...", "Connecting..."] or status in ["Resuming...", "Starting...", "Pending...", "Connecting..."]
                 
-                if not is_complete:
+                if not is_complete and not is_resuming_or_connecting:
                     if is_active:
                         selection_has_active = True
                         selection_has_pausable = True
-                        if not is_resuming:
-                            selection_has_resumable = True
                     else:
-                        if not is_resuming:
-                            selection_has_resumable = True
+                        selection_has_resumable = True
+                elif is_active:
+                    selection_has_pausable = True
         
         # STOP action is for pausing an active download
         self.action_stop.setEnabled(selection_has_pausable)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1305,21 +1305,25 @@ class MainWindow(QMainWindow):
                 
                 status_item = self.download_table.item(r, 2)
                 logic_status = status_item.data(Qt.ItemDataRole.UserRole + 1) if status_item else None
-                status = logic_status if logic_status else (status_item.text() if status_item else "")
+                status_text = status_item.text() if status_item else ""
+                status = logic_status if logic_status else status_text
                 
                 is_active = self._is_download_active(item)
                 if is_active:
                     selection_has_active = True
                 
                 is_complete = status in ["Complete", "Finished"] or (item.data(Qt.ItemDataRole.UserRole + 11) == "Complete")
+                is_resuming = logic_status == "Resuming..." or status == "Resuming..." or status_text == "Resuming..."
                 
                 if not is_complete:
                     if is_active:
                         selection_has_active = True
                         selection_has_pausable = True
-                        selection_has_resumable = True
+                        if not is_resuming:
+                            selection_has_resumable = True
                     else:
-                        selection_has_resumable = True
+                        if not is_resuming:
+                            selection_has_resumable = True
         
         # STOP action is for pausing an active download
         self.action_stop.setEnabled(selection_has_pausable)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1111,12 +1111,23 @@ class MainWindow(QMainWindow):
             if icon.isNull():
                 icon = self.style().standardIcon(QStyle.StandardPixmap.SP_DriveNetIcon)
             self.tray_icon.setIcon(icon)        
-            # Create dynamic tray menu
-            self.tray_menu = QMenu(self)
-            self.tray_menu.aboutToShow.connect(self._rebuild_tray_menu)
-            self._rebuild_tray_menu()
-
-            self.tray_icon.setContextMenu(self.tray_menu)
+            # Create tray menu
+            tray_menu = QMenu(self)
+            
+            # Show/Hide Action
+            self.action_tray_toggle = QAction("Hide", self) # Default to Hide as window starts visible
+            self.action_tray_toggle.setIcon(get_themed_icon("show_hide"))
+            self.action_tray_toggle.triggered.connect(self.toggle_window)
+            
+            tray_menu.addAction(self.action_tray_toggle)
+            tray_menu.addSeparator()
+            tray_menu.addAction(self.action_add_url)
+            tray_menu.addAction(self.action_media_downloader)
+            tray_menu.addAction(self.action_options)
+            tray_menu.addSeparator()
+            tray_menu.addAction(self.action_exit)
+            
+            self.tray_icon.setContextMenu(tray_menu)
             self.tray_icon.setToolTip("Bengal Download Manager")
             self.tray_icon.show()
             
@@ -1125,16 +1136,6 @@ class MainWindow(QMainWindow):
         except Exception as e:
             print(f"Warning: System tray icon initialization failed ({e})")
             self.tray_icon = None
-
-    def _find_row_by_key(self, key):
-        """Finds table row index corresponding to a persistent item key."""
-        if not key or not hasattr(self, "download_table"):
-            return -1
-        for r in range(self.download_table.rowCount()):
-            item_0 = self.download_table.item(r, 0)
-            if item_0 and self._get_item_key(item_0) == key:
-                return r
-        return -1
 
     def show_download_progress_dialog(self, target):
         """
@@ -1185,75 +1186,9 @@ class MainWindow(QMainWindow):
         for key in active_keys:
             self.show_download_progress_dialog(key)
 
-    def _rebuild_tray_menu(self):
-        """Dynamically populates the system tray context menu with active downloads and actions."""
-        if not hasattr(self, "tray_menu") or self.tray_menu is None:
-            return
-
-        self.tray_menu.clear()
-
-        # 1. Active Downloads Section
-        active_entries = []
-        for key in list(getattr(self, "active_downloads", {}).keys()):
-            row = self._find_row_by_key(key)
-            if row >= 0:
-                item_0 = self.download_table.item(row, 0)
-                if item_0 and self._is_download_active(item_0):
-                    filename = item_0.text()
-                    status_item = self.download_table.item(row, 2)
-                    speed_item = self.download_table.item(row, 4)
-                    status_str = status_item.text() if status_item else ""
-                    speed_str = speed_item.text() if speed_item else ""
-                    active_entries.append((key, filename, status_str, speed_str))
-
-        if active_entries:
-            for key, filename, status_str, speed_str in active_entries:
-                display_name = filename if len(filename) <= 30 else (filename[:27] + "...")
-                desc_parts = []
-                if status_str and status_str not in ["Downloading", "Running"]:
-                    desc_parts.append(status_str)
-                if speed_str and speed_str not in ["0 B/s", "0.00 B/s"]:
-                    desc_parts.append(speed_str)
-                suffix = f" ({' — '.join(desc_parts)})" if desc_parts else ""
-                
-                label = f"{display_name}{suffix}"
-                act = QAction(get_themed_icon("resume"), label, self)
-                act.setToolTip(f"Bring progress window to front: {filename}")
-                act.triggered.connect(lambda _, k=key: self.show_download_progress_dialog(k))
-                self.tray_menu.addAction(act)
-
-            if len(active_entries) > 1:
-                act_all = QAction(get_themed_icon("show_hide"), "Show All Active Downloads", self)
-                act_all.triggered.connect(self.show_all_active_progress_dialogs)
-                self.tray_menu.addAction(act_all)
-
-            self.tray_menu.addSeparator()
-
-        # 2. Main Window Show/Hide Toggle
-        if not hasattr(self, "action_tray_toggle") or self.action_tray_toggle is None:
-            self.action_tray_toggle = QAction("Hide", self)
-            self.action_tray_toggle.setIcon(get_themed_icon("show_hide"))
-            self.action_tray_toggle.triggered.connect(self.toggle_window)
-        self.update_tray_action()
-        self.tray_menu.addAction(self.action_tray_toggle)
-
-        self.tray_menu.addSeparator()
-        self.tray_menu.addAction(self.action_add_url)
-        self.tray_menu.addAction(self.action_media_downloader)
-        self.tray_menu.addAction(self.action_options)
-        self.tray_menu.addSeparator()
-        self.tray_menu.addAction(self.action_exit)
-
     def on_tray_icon_activated(self, reason):
         if reason in (QSystemTrayIcon.ActivationReason.Trigger, QSystemTrayIcon.ActivationReason.DoubleClick):
-            if not self.isVisible() or self.isMinimized():
-                self.restore_window()
-                self.show_all_active_progress_dialogs()
-            else:
-                if getattr(self, "active_downloads", {}):
-                    self.show_all_active_progress_dialogs()
-                else:
-                    self.toggle_window()
+            self.toggle_window()
 
     def restore_window(self):
         """Restores the window from minimized or hidden state and brings it to the foreground."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1716,13 +1716,32 @@ def test_options_dialog_silent_download_mode(qapp, monkeypatch, tmp_path):
     assert hasattr(dlg, "chk_silent_download")
     assert dlg.get_silent_download() is False
 
-    # Check silent download mode
+    # Initial states should be enabled and checked
+    assert dlg.chk_show_start_dialog.isChecked() is True
+    assert dlg.chk_show_progress_dialog.isChecked() is True
+    assert dlg.chk_show_complete_dialog.isChecked() is True
+
+    # Check silent download mode (should disable controls without clearing their checked state)
     dlg.chk_silent_download.setChecked(True)
     assert dlg.chk_show_start_dialog.isEnabled() is False
     assert dlg.chk_show_progress_dialog.isEnabled() is False
     assert dlg.chk_show_complete_dialog.isEnabled() is False
     assert dlg.chk_show_queue_complete_dialog.isEnabled() is False
+    assert dlg.chk_show_start_dialog.isChecked() is True
+    assert dlg.chk_show_progress_dialog.isChecked() is True
+    assert dlg.chk_show_complete_dialog.isChecked() is True
 
+    # Uncheck silent download mode (should re-enable controls while preserving checked state)
+    dlg.chk_silent_download.setChecked(False)
+    assert dlg.chk_show_start_dialog.isEnabled() is True
+    assert dlg.chk_show_progress_dialog.isEnabled() is True
+    assert dlg.chk_show_complete_dialog.isEnabled() is True
+    assert dlg.chk_show_queue_complete_dialog.isEnabled() is True
+    assert dlg.chk_show_start_dialog.isChecked() is True
+    assert dlg.chk_show_progress_dialog.isChecked() is True
+    assert dlg.chk_show_complete_dialog.isChecked() is True
+
+    dlg.chk_silent_download.setChecked(True)
     dlg.save_and_accept()
     assert win.settings["silent_download"] is True
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1794,6 +1794,136 @@ def test_options_dialog_tooltips_presence(qapp, monkeypatch, tmp_path):
     dlg.close()
 
 
+def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, tmp_path):
+    """Verify silent or hidden progress dialogs can be restored from tray menu, tray activation, and table double-click."""
+    from ui.main_window import MainWindow
+    from PyQt6.QtWidgets import QSystemTrayIcon, QTableWidgetItem
+    from PyQt6.QtCore import Qt
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(QSystemTrayIcon, "isSystemTrayAvailable", lambda: True)
+
+    win = MainWindow(start_ipc=False)
+    win.hide()
+
+    class MockWorker:
+        def __init__(self):
+            self.filename = "test_archive.zip"
+            self.url = "http://example.com/test_archive.zip"
+            self.target_path = str(tmp_path / "test_archive.zip")
+            self.total_bytes = 1000000
+            self.is_paused = False
+            self.is_pause_requested = False
+            self.row_index = 0
+
+            # Mock PyQt signals
+            from PyQt6.QtCore import QObject, pyqtSignal
+            class SignalEmitter(QObject):
+                log_signal = pyqtSignal(str)
+                main_bar_signal = pyqtSignal(int, int)
+                main_progress_signal = pyqtSignal(int, tuple)
+                finished_signal = pyqtSignal(int, str)
+                init_segments_signal = pyqtSignal(int)
+                segment_update_signal = pyqtSignal(int, tuple)
+            
+            self._signals = SignalEmitter()
+            self.log_signal = self._signals.log_signal
+            self.main_bar_signal = self._signals.main_bar_signal
+            self.main_progress_signal = self._signals.main_progress_signal
+            self.finished_signal = self._signals.finished_signal
+            self.init_segments_signal = self._signals.init_segments_signal
+            self.segment_update_signal = self._signals.segment_update_signal
+
+        def format_bytes(self, b, precision=2, pad=False):
+            return f"{b} B"
+
+        def isRunning(self):
+            return True
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    worker = MockWorker()
+
+    win.download_table.setRowCount(1)
+    item_name = QTableWidgetItem(worker.filename)
+    item_size = QTableWidgetItem("1 MB")
+    item_status = QTableWidgetItem("Downloading (50%)")
+    item_status.setData(Qt.ItemDataRole.UserRole + 1, "Downloading")
+    item_time = QTableWidgetItem("10s")
+    item_speed = QTableWidgetItem("2.5 MB/s")
+    item_try = QTableWidgetItem("Now")
+    item_date = QTableWidgetItem("Today")
+
+    win.download_table.setItem(0, 0, item_name)
+    win.download_table.setItem(0, 1, item_size)
+    win.download_table.setItem(0, 2, item_status)
+    win.download_table.setItem(0, 3, item_time)
+    win.download_table.setItem(0, 4, item_speed)
+    win.download_table.setItem(0, 5, item_try)
+    win.download_table.setItem(0, 6, item_date)
+
+    key = win._get_item_key(item_name)
+    win.active_downloads[key] = worker
+
+    # 1. Dynamic tray menu test
+    win._rebuild_tray_menu()
+    actions = win.tray_menu.actions()
+    matching_actions = [a for a in actions if "test_archive.zip" in a.text()]
+    assert len(matching_actions) == 1
+    assert "Downloading (50%)" in matching_actions[0].text() or "2.5 MB/s" in matching_actions[0].text()
+
+    # 2. Clicking tray action restores/creates progress dialog
+    matching_actions[0].trigger()
+    assert key in win.active_downloads
+    dlg = win.active_downloads[key]
+    assert dlg.isVisible() is True
+    assert "test_archive.zip" in dlg.windowTitle()
+
+    # Hide dialog
+    dlg.hide()
+    assert dlg.isVisible() is False
+
+    # 3. show_all_active_progress_dialogs
+    win.show_all_active_progress_dialogs()
+    assert dlg.isVisible() is True
+
+    dlg.hide()
+
+    # 4. Table cellDoubleClicked
+    win._on_table_cell_double_clicked(0, 0)
+    assert dlg.isVisible() is True
+
+    # 5. Tray icon activation when window visible brings dialog to front
+    dlg.hide()
+    win.show()
+    win.on_tray_icon_activated(QSystemTrayIcon.ActivationReason.Trigger)
+    assert dlg.isVisible() is True
+
+    # 6. Context menu "Show progress window"
+    dlg.hide()
+    from PyQt6.QtCore import QPoint
+    from PyQt6.QtWidgets import QMenu
+    captured_menus = []
+    real_exec = QMenu.exec
+    monkeypatch.setattr(QMenu, "exec", lambda m, *a, **k: captured_menus.append(m))
+    win.show_context_menu(QPoint(5, 5))
+    if captured_menus:
+        ctx_acts = captured_menus[-1].actions()
+        prog_acts = [a for a in ctx_acts if "Show progress window" in a.text()]
+        assert len(prog_acts) == 1
+        assert prog_acts[0].isEnabled() is True
+        prog_acts[0].trigger()
+        assert dlg.isVisible() is True
+
+    dlg.close()
+    win.close()
+
+
+
 
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1361,7 +1361,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert item0.data(Qt.ItemDataRole.UserRole + 11) == "Normal"
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
 
     # 2. DOWNLOAD WINDOW (DIALOG) PAUSE & RESUME
     dlg.btn_pause.setText("Pause")
@@ -1376,7 +1376,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert mock_worker.is_paused is False
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
 
     # 3. RIGHT-CLICK CONTEXT MENU PAUSE & RESUME
     window.stop_selected_download()
@@ -1389,7 +1389,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert mock_worker.is_paused is False
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
 
     # 4. CROSS-INTERFACE ALTERNATING SWITCHES
     # Toolbar Pause -> Window Resume
@@ -1916,6 +1916,35 @@ def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, t
     assert dlg.isVisible() is True
 
     dlg.close()
+    win.close()
+
+
+def test_toolbar_resume_disabled_when_already_resuming(qapp, monkeypatch, tmp_path):
+    """Verify that toolbar Resume action is disabled when a download is actively in Resuming state."""
+    from ui.main_window import MainWindow
+    from PyQt6.QtWidgets import QTableWidgetItem
+    from PyQt6.QtCore import Qt
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    win = MainWindow(start_ipc=False)
+    win.hide()
+
+    win.download_table.setRowCount(1)
+    item_name = QTableWidgetItem("resuming_file.iso")
+    item_status = QTableWidgetItem("Resuming...")
+    item_status.setData(Qt.ItemDataRole.UserRole + 1, "Resuming...")
+
+    win.download_table.setItem(0, 0, item_name)
+    win.download_table.setItem(0, 1, QTableWidgetItem("100 MB"))
+    win.download_table.setItem(0, 2, item_status)
+
+    win.download_table.selectRow(0)
+    win.update_ui_states()
+
+    # Toolbar Resume should be disabled because the download is already resuming
+    assert win.action_resume.isEnabled() is False
+
     win.close()
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1869,17 +1869,10 @@ def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, t
     key = win._get_item_key(item_name)
     win.active_downloads[key] = worker
 
-    # 1. Dynamic tray menu test
-    win._rebuild_tray_menu()
-    actions = win.tray_menu.actions()
-    matching_actions = [a for a in actions if "test_archive.zip" in a.text()]
-    assert len(matching_actions) == 1
-    assert "Downloading (50%)" in matching_actions[0].text() or "2.5 MB/s" in matching_actions[0].text()
-
-    # 2. Clicking tray action restores/creates progress dialog
-    matching_actions[0].trigger()
+    # 1. show_download_progress_dialog restores/creates progress dialog
+    dlg = win.show_download_progress_dialog(key)
     assert key in win.active_downloads
-    dlg = win.active_downloads[key]
+    assert dlg is not None
     assert dlg.isVisible() is True
     assert "test_archive.zip" in dlg.windowTitle()
 
@@ -1887,23 +1880,17 @@ def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, t
     dlg.hide()
     assert dlg.isVisible() is False
 
-    # 3. show_all_active_progress_dialogs
+    # 2. show_all_active_progress_dialogs
     win.show_all_active_progress_dialogs()
     assert dlg.isVisible() is True
 
     dlg.hide()
 
-    # 4. Table cellDoubleClicked
+    # 3. Table cellDoubleClicked
     win._on_table_cell_double_clicked(0, 0)
     assert dlg.isVisible() is True
 
-    # 5. Tray icon activation when window visible brings dialog to front
-    dlg.hide()
-    win.show()
-    win.on_tray_icon_activated(QSystemTrayIcon.ActivationReason.Trigger)
-    assert dlg.isVisible() is True
-
-    # 6. Context menu "Show progress window"
+    # 4. Context menu "Show progress window"
     dlg.hide()
     from PyQt6.QtCore import QPoint
     from PyQt6.QtWidgets import QMenu

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1337,7 +1337,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert window.download_table.item(row, 2).text() == "50.00%"
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
 
     # 1. TOOLBAR PAUSE & RESUME
     window.action_stop.trigger()
@@ -1361,7 +1361,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert item0.data(Qt.ItemDataRole.UserRole + 11) == "Normal"
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
 
     # 2. DOWNLOAD WINDOW (DIALOG) PAUSE & RESUME
     dlg.btn_pause.setText("Pause")
@@ -1376,7 +1376,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert mock_worker.is_paused is False
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
 
     # 3. RIGHT-CLICK CONTEXT MENU PAUSE & RESUME
     window.stop_selected_download()
@@ -1389,7 +1389,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert mock_worker.is_paused is False
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is False
+    assert window.action_resume.isEnabled() is True
 
     # 4. CROSS-INTERFACE ALTERNATING SWITCHES
     # Toolbar Pause -> Window Resume
@@ -1905,6 +1905,15 @@ def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, t
         assert prog_acts[0].isEnabled() is True
         prog_acts[0].trigger()
         assert dlg.isVisible() is True
+
+    # 5. Toolbar Resume action brings back progress dialog like IDM
+    dlg.hide()
+    assert dlg.isVisible() is False
+    win.download_table.selectRow(0)
+    win.update_ui_states()
+    assert win.action_resume.isEnabled() is True
+    win.action_resume.trigger()
+    assert dlg.isVisible() is True
 
     dlg.close()
     win.close()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1337,7 +1337,7 @@ def test_pause_resume_multi_interface_lifecycle(qapp, monkeypatch):
     assert window.download_table.item(row, 2).text() == "50.00%"
     assert window._is_row_active(row) is True
     assert window.action_stop.isEnabled() is True
-    assert window.action_resume.isEnabled() is True
+    assert window.action_resume.isEnabled() is False
 
     # 1. TOOLBAR PAUSE & RESUME
     window.action_stop.trigger()
@@ -1905,15 +1905,6 @@ def test_restore_silent_or_hidden_progress_dialog_from_tray(qapp, monkeypatch, t
         assert prog_acts[0].isEnabled() is True
         prog_acts[0].trigger()
         assert dlg.isVisible() is True
-
-    # 5. Toolbar Resume action brings back progress dialog like IDM
-    dlg.hide()
-    assert dlg.isVisible() is False
-    win.download_table.selectRow(0)
-    win.update_ui_states()
-    assert win.action_resume.isEnabled() is True
-    win.action_resume.trigger()
-    assert dlg.isVisible() is True
 
     dlg.close()
     win.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -421,4 +421,76 @@ def test_get_aria2_proxy_url():
     assert get_aria2_proxy_url({"mode": "manual", "host": ""}) == ""
 
 
+def test_user_home_and_downloads_dir_in_snap(monkeypatch, tmp_path):
+    from core.utils import get_user_home_dir, get_user_downloads_dir
+    from core.config import get_default_categories, load_category_config, save_category_config
+
+    real_user_home = tmp_path / "home_user"
+    real_user_home.mkdir()
+    real_downloads = real_user_home / "Downloads"
+    real_downloads.mkdir()
+
+    snap_user_data = tmp_path / "snap" / "bengal-download-manager" / "x1"
+    snap_user_data.mkdir(parents=True)
+    snap_downloads = snap_user_data / "Downloads"
+    snap_downloads.mkdir()
+
+    # Simulate standard environment
+    monkeypatch.delenv("SNAP_REAL_HOME", raising=False)
+    monkeypatch.delenv("SNAP_USER_DATA", raising=False)
+    monkeypatch.setenv("HOME", str(real_user_home))
+    assert get_user_home_dir() == str(real_user_home)
+    assert get_user_downloads_dir() == str(real_downloads)
+
+    # Simulate Snap confinement environment
+    monkeypatch.setenv("SNAP_REAL_HOME", str(real_user_home))
+    monkeypatch.setenv("SNAP_USER_DATA", str(snap_user_data))
+    monkeypatch.setenv("HOME", str(snap_user_data))
+
+    assert get_user_home_dir() == str(real_user_home)
+    assert get_user_downloads_dir() == str(real_downloads)
+
+    # Test XDG user-dirs custom download directory in Snap
+    custom_down = real_user_home / "MyCustomDownloads"
+    custom_down.mkdir()
+    config_dir = real_user_home / ".config"
+    config_dir.mkdir()
+    (config_dir / "user-dirs.dirs").write_text(f'XDG_DOWNLOAD_DIR="{custom_down}"\n')
+    assert get_user_downloads_dir() == str(custom_down)
+
+    # Reset config_dir user-dirs.dirs
+    (config_dir / "user-dirs.dirs").unlink()
+    assert get_user_downloads_dir() == str(real_downloads)
+
+    # Test default categories reflect real downloads folder
+    cats = get_default_categories()
+    assert cats["General"]["path"] == str(real_downloads)
+    assert cats["Compressed"]["path"] == str(real_downloads / "Compressed")
+
+    # Test load_category_config migrates snap user data paths to real home
+    fake_config_dir = tmp_path / "app_config"
+    monkeypatch.setattr("core.config.get_config_dir", lambda: str(fake_config_dir))
+    fake_config_dir.mkdir()
+
+    old_snap_categories = {
+        "categories": {
+            "General": {
+                "path": str(snap_downloads),
+                "extensions": "plj"
+            },
+            "Compressed": {
+                "path": str(snap_downloads / "Compressed"),
+                "extensions": "7z zip"
+            }
+        },
+        "temp_dir": "/tmp"
+    }
+    save_category_config(old_snap_categories)
+
+    loaded = load_category_config()
+    assert loaded["categories"]["General"]["path"] == str(real_downloads)
+    assert loaded["categories"]["Compressed"]["path"] == str(real_downloads / "Compressed")
+
+
+
 


### PR DESCRIPTION
## Summary
- **Snap Downloads Directory Fix**: Added `get_user_home_dir()` (reading `$SNAP_REAL_HOME` inside Snap) and `get_user_downloads_dir()` (inspecting XDG user-dirs or host `~/Downloads`) so Snap builds save downloads to host user `~/Downloads` rather than sandboxed `/home/<user>/snap/bengal-download-manager/<rev>/Downloads`.
- **Snap Category Path Migration**: Updated `load_category_config()` to migrate sandboxed snap directory paths to real host downloads folder.
- **Options Dialog State Preservation**: Fixed `_on_silent_toggled` in Options Dialog so checking/unchecking silent download mode disables/enables dialog checkboxes without wiping user selection states.
- **Automated Tests**: Added unit tests in `tests/test_utils.py` and `tests/test_ui.py`.