### PR TITLE
fix(core,ui): resolve filename from content-disposition/query params & display referer in properties

### DIFF
--- a/src/core/services/ipc_service.py
+++ b/src/core/services/ipc_service.py
@@ -69,18 +69,20 @@ class IPCRequestHandler(BaseHTTPRequestHandler):
         url = ""
         user_agent = ""
         cookies = ""
+        referrer = ""
         
         try:
             payload = json.loads(body)
             url = payload.get("url", "")
             user_agent = payload.get("userAgent", "")
             cookies = payload.get("cookies", "")
+            referrer = payload.get("referrer", "")
         except json.JSONDecodeError:
             url = body
             
         if url and url.startswith("http"):
             # self.server.emitter is passed when initializing the server
-            self.server.emitter.new_download_signal.emit(f"{url}|{user_agent}|{cookies}")
+            self.server.emitter.new_download_signal.emit(f"{url}|{user_agent}|{cookies}|{referrer}")
             
             self.send_response(200)
             self.send_header('Access-Control-Allow-Origin', '*')

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -9,7 +9,8 @@ import tarfile
 import subprocess
 import re
 import logging
-from urllib.parse import urlparse, unquote
+import mimetypes
+from urllib.parse import urlparse, unquote, parse_qs
 
 def setup_logging(debug=False):
     """
@@ -107,40 +108,74 @@ def get_process_memory() -> int:
 def resolve_filename(url, headers):
     """
     JDownloader-style robust filename resolution:
-    1. Content-Disposition (RFC 5987 filename* > filename)
-    2. URL path (last segment)
-    3. Extension correction (replace .php/.asp etc. with real extension from MIME)
-    4. Fallback to 'downloaded_file'
+    1. Content-Disposition header (RFC 5987 filename* > filename)
+    2. URL query parameters (response-content-disposition, rscd, filename, file, name)
+    3. URL path (last segment, filtering out raw UUIDs/hashes)
+    4. Extension correction (replace script extensions or missing extensions with MIME type)
+    5. Unknown MIME types and valid filenames preserved as-is
+    6. Fallback to 'downloaded_file'
     """
     filename = None
     
-    # --- 1. Content-Disposition (Highest Priority for Generic Links) ---
-    cd = headers.get("Content-Disposition")
-    if cd:
+    def _parse_cd(cd_str):
+        if not cd_str or not isinstance(cd_str, str):
+            return None
         # RFC 5987 filename*
-        cd_match = re.search(r"filename\*=UTF-8''([^\"';]+)", cd, re.IGNORECASE)
+        cd_match = re.search(r"filename\*=UTF-8''([^\"';]+)", cd_str, re.IGNORECASE)
         if not cd_match:
             # Standard filename
-            cd_match = re.search(r'filename=["\']?([^"\';]+)[\"\']?', cd, re.IGNORECASE)
-        
+            cd_match = re.search(r'filename=["\']?([^"\';\r\n]+)', cd_str, re.IGNORECASE)
         if cd_match:
-            filename = unquote(cd_match.group(1).strip())
-            filename = os.path.basename(filename) # Sanitization
-            # Filter out UUIDs/Hashes which JD2 also ignores if better name available
-            if filename and (
-                re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', filename, re.I) or
-                re.match(r'^[0-9a-f]{32,64}$', filename, re.I)
+            fn = unquote(cd_match.group(1).strip())
+            fn = os.path.basename(fn) # Sanitization
+            if fn and not (
+                re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', fn, re.I) or
+                re.match(r'^[0-9a-f]{32,64}$', fn, re.I)
             ):
-                filename = None
+                return fn
+        return None
 
-    # --- 2. URL Path Extraction ---
-    if not filename:
+    # --- 1. Content-Disposition Header (Highest Priority) ---
+    cd = headers.get("Content-Disposition")
+    if cd:
+        filename = _parse_cd(cd)
+
+    # --- 2. Query Parameters (Cloud Storage / Presigned URL / S3 / Azure CDN) ---
+    effective_url = headers.get("Location") or url
+    if not filename and effective_url:
         try:
-            # Check for location header if present (for manual redirect analysis)
-            effective_url = headers.get("Location") or url
+            parsed = urlparse(effective_url)
+            if parsed.query:
+                qs = parse_qs(parsed.query)
+                for key in ["response-content-disposition", "rscd", "content-disposition"]:
+                    for val in qs.get(key, []):
+                        fn = _parse_cd(val)
+                        if fn:
+                            filename = fn
+                            break
+                    if filename:
+                        break
+                if not filename:
+                    for key in ["filename", "file", "name", "file_name"]:
+                        for val in qs.get(key, []):
+                            val_clean = os.path.basename(unquote(val.strip()))
+                            if val_clean and val_clean not in ["", "/", "."] and not (
+                                re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', val_clean, re.I) or
+                                re.match(r'^[0-9a-f]{32,64}$', val_clean, re.I) or
+                                val_clean.isdigit()
+                            ):
+                                filename = val_clean
+                                break
+                        if filename:
+                            break
+        except Exception:
+            pass
+
+    # --- 3. URL Path Extraction ---
+    if not filename and effective_url:
+        try:
             parsed = urlparse(effective_url)
             path = unquote(parsed.path)
-            # Remove trailing slashes
             path = path.rstrip('/')
             basename = os.path.basename(path)
             
@@ -150,15 +185,15 @@ def resolve_filename(url, headers):
                 basename.isdigit()
             ):
                 filename = basename
-        except:
+        except Exception:
             pass
 
-    # --- 3. JDownloader-style Extension Correction ---
-    # Determine the "Real" extension from Content-Type
+    # --- 4. MIME-type Extension Detection / Correction ---
     content_type = headers.get("Content-Type", "").split(';')[0].strip().lower()
     real_extension = None
     if content_type:
         mime_map = {
+            'application/vnd.android.package-archive': '.apk',
             'application/x-msdownload': '.exe',
             'application/octet-stream': '.bin',
             'application/x-executable': '.exe',
@@ -167,30 +202,48 @@ def resolve_filename(url, headers):
             'application/zip': '.zip',
             'application/x-7z-compressed': '.7z',
             'application/x-rar-compressed': '.rar',
+            'application/x-tar': '.tar',
+            'application/gzip': '.tar.gz',
+            'application/x-gzip': '.tar.gz',
+            'application/x-bzip2': '.tar.bz2',
+            'application/x-xz': '.tar.xz',
             'application/pdf': '.pdf',
+            'application/json': '.json',
+            'application/xml': '.xml',
             'image/jpeg': '.jpg',
             'image/png': '.png',
+            'image/webp': '.webp',
+            'image/gif': '.gif',
+            'image/svg+xml': '.svg',
             'video/mp4': '.mp4',
-            'audio/mpeg': '.mp3'
+            'video/x-matroska': '.mkv',
+            'video/webm': '.webm',
+            'audio/mpeg': '.mp3',
+            'audio/ogg': '.ogg',
+            'audio/flac': '.flac',
+            'audio/wav': '.wav'
         }
         real_extension = mime_map.get(content_type)
         if not real_extension:
-            exts = mimetypes.guess_all_extensions(content_type)
-            if exts:
-                # Preference list
-                if '.exe' in exts: real_extension = '.exe'
-                elif '.zip' in exts: real_extension = '.zip'
-                elif '.jpg' in exts: real_extension = '.jpg'
-                else: real_extension = exts[0]
+            try:
+                exts = mimetypes.guess_all_extensions(content_type)
+                if exts:
+                    if '.apk' in exts: real_extension = '.apk'
+                    elif '.exe' in exts: real_extension = '.exe'
+                    elif '.zip' in exts: real_extension = '.zip'
+                    elif '.jpg' in exts: real_extension = '.jpg'
+                    else: real_extension = exts[0]
+            except Exception:
+                pass
 
     if not filename:
         filename = "downloaded_file"
-        if real_extension:
+        if real_extension and real_extension != '.bin':
             filename += real_extension
     else:
         # CORRECTION LOGIC:
         # If we have a filename but its extension is a script (.php, .asp) or missing, 
-        # replace/append with the real one.
+        # replace/append with the real one. Unknown MIME types leave filename as is.
         script_exts = ['.php', '.asp', '.aspx', '.jsp', '.cfm', '.cgi', '.pl', '.html', '.htm']
         base, current_ext = os.path.splitext(filename)
         current_ext = current_ext.lower()

--- a/src/core/workers/download.py
+++ b/src/core/workers/download.py
@@ -11,7 +11,7 @@ class SegmentWorker(QThread):
     progress_signal = pyqtSignal(int, object, object, float, str)
     finished_signal = pyqtSignal(int, bool)
 
-    def __init__(self, index, url, start_byte, end_byte, filepath, initial_downloaded=0, opener=None, user_agent=None, cookies=None):
+    def __init__(self, index, url, start_byte, end_byte, filepath, initial_downloaded=0, opener=None, user_agent=None, cookies=None, referrer=None):
         super().__init__()
         self.index = index
         self.url = url
@@ -22,6 +22,7 @@ class SegmentWorker(QThread):
         self.opener = opener
         self.user_agent = user_agent
         self.cookies = cookies
+        self.referrer = referrer
         
         self.is_running = True
         self.is_paused = False
@@ -53,9 +54,11 @@ class SegmentWorker(QThread):
             if self.cookies:
                 req.add_header('Cookie', self.cookies)
             
-            # Add Referer if possible (use base domain)
-            parsed = urlparse(self.url)
-            req.add_header('Referer', f"{parsed.scheme}://{parsed.netloc}/")
+            if self.referrer:
+                req.add_header('Referer', self.referrer)
+            else:
+                parsed = urlparse(self.url)
+                req.add_header('Referer', f"{parsed.scheme}://{parsed.netloc}/")
             
             self.progress_signal.emit(self.index, self.downloaded, self.total_size, 0, "Resume GET...")
             
@@ -139,7 +142,7 @@ class DownloadWorker(QThread):
     segment_update_signal = pyqtSignal(int, object, object, float, str) 
     init_segments_signal = pyqtSignal(int) 
 
-    def __init__(self, url, row_index, save_dir, resume_filename=None, user_agent=None, cookies=None, temp_dir=None, allow_resume=True):
+    def __init__(self, url, row_index, save_dir, resume_filename=None, user_agent=None, cookies=None, temp_dir=None, referrer=None, allow_resume=True):
         super().__init__()
         self.url = url
         self.row_index = row_index
@@ -147,6 +150,7 @@ class DownloadWorker(QThread):
         self.temp_dir = temp_dir
         self.user_agent = user_agent
         self.cookies = cookies
+        self.referrer = referrer
         self.allow_resume = allow_resume
         self.is_running = True
         self.is_paused = False
@@ -222,6 +226,11 @@ class DownloadWorker(QThread):
                 req.add_header('Cookie', self.cookies)
             if self.user_agent:
                 req.add_header('User-Agent', self.user_agent)
+            if self.referrer:
+                req.add_header('Referer', self.referrer)
+            else:
+                parsed = urlparse(self.url)
+                req.add_header('Referer', f"{parsed.scheme}://{parsed.netloc}/")
 
             with self.opener.open(req) as response:
                 total_size = int(response.info().get('Content-Length', 0))
@@ -279,7 +288,7 @@ class DownloadWorker(QThread):
                 end = seg["end"]
                 initial_dl = seg.get("downloaded", 0)
                 
-                worker = SegmentWorker(idx, self.url, start, end, self.save_path, initial_dl, opener=self.opener, user_agent=self.user_agent, cookies=self.cookies)
+                worker = SegmentWorker(idx, self.url, start, end, self.save_path, initial_dl, opener=self.opener, user_agent=self.user_agent, cookies=self.cookies, referrer=self.referrer)
                 worker.progress_signal.connect(self.update_segment_stat)
                 self.workers.append(worker)
                 

--- a/src/core/workers/fetcher.py
+++ b/src/core/workers/fetcher.py
@@ -10,9 +10,10 @@ from core.utils import load_extension_config, resolve_filename
 class FileInfoFetcherWorker(QThread):
     finished_signal = pyqtSignal(dict)
     
-    def __init__(self, url, user_agent=None, cookies=None):
+    def __init__(self, url, user_agent=None, cookies=None, referrer=None):
         super().__init__()
         self.url = url
+        self.referrer = referrer
         # Use Chrome UA by default as it's more widely accepted by WAFs
         self.user_agent = user_agent or "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
         self.cookies = cookies
@@ -42,6 +43,7 @@ class FileInfoFetcherWorker(QThread):
             "size_bytes": 0,
             "user_agent": self.user_agent,
             "cookies": self.cookies,
+            "referer": self.referrer or self.url,
             "error": None
         }
         
@@ -59,8 +61,11 @@ class FileInfoFetcherWorker(QThread):
             if self.cookies:
                 headers['Cookie'] = self.cookies
 
-            parsed_orig = urlparse(self.url)
-            headers['Referer'] = f"{parsed_orig.scheme}://{parsed_orig.netloc}/"
+            if self.referrer:
+                headers['Referer'] = self.referrer
+            else:
+                parsed_orig = urlparse(self.url)
+                headers['Referer'] = f"{parsed_orig.scheme}://{parsed_orig.netloc}/"
 
             opener = self.create_opener()
             
@@ -87,6 +92,7 @@ class FileInfoFetcherWorker(QThread):
 
                     # We found a binary or an explicit attachment!
                     result["url"] = final_url
+                    result["referer"] = self.url if final_url != self.url else (self.referrer or self.url)
                     result["filename"] = resolve_filename(final_url, final_headers)
                     
                     content_length = final_headers.get("Content-Length")

--- a/src/ui/dialogs/properties.py
+++ b/src/ui/dialogs/properties.py
@@ -31,6 +31,7 @@ class PropertiesDialog(QDialog):
             ("Size:", file_data.get('size', 'Unknown')),
             ("Saved To:", os.path.dirname(file_data.get('path', 'Unknown'))),
             ("Address:", file_data.get('url', '')),
+            ("Referer:", file_data.get('referer') or file_data.get('referrer') or file_data.get('url', '')),
             ("Date Added:", file_data.get('date_added', '')),
             ("Last Try:", file_data.get('last_try', ''))
         ]

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1857,6 +1857,9 @@ class MainWindow(QMainWindow):
                     "last_try": str(last_try_ts),   # Save raw timestamp
                     "date_added": str(date_added_ts), # Save raw timestamp
                     "queue": item_name.data(Qt.ItemDataRole.UserRole + 8) if item_name.data(Qt.ItemDataRole.UserRole + 8) is not None else "Main download queue",
+                    "extra_data": {
+                        "referer": item_name.data(Qt.ItemDataRole.UserRole + 15) or url
+                    }
                 }
                 downloads.append(dl_data)
             
@@ -1890,6 +1893,8 @@ class MainWindow(QMainWindow):
                 item_name.setData(Qt.ItemDataRole.UserRole + 2, last_try_ts)   # Raw Last Try TS
                 item_name.setData(Qt.ItemDataRole.UserRole + 3, date_added_ts) # Raw Date Added TS
                 item_name.setData(Qt.ItemDataRole.UserRole + 8, d.get("queue", "Main download queue") if d.get("queue") is not None else "Main download queue")  # Queue
+                extra = d.get("extra_data", {})
+                item_name.setData(Qt.ItemDataRole.UserRole + 15, extra.get("referer", d.get("url", "")) if isinstance(extra, dict) else d.get("url", ""))
                 item_name.setIcon(get_file_icon(filename))
                 
                 self.download_table.setItem(row, 0, item_name)
@@ -2126,6 +2131,7 @@ class MainWindow(QMainWindow):
                 data.append({
                     "filename": item0.text(),
                     "url": item0.data(Qt.ItemDataRole.UserRole) or "",
+                    "referer": item0.data(Qt.ItemDataRole.UserRole + 15) or item0.data(Qt.ItemDataRole.UserRole) or "",
                     "path": item0.data(Qt.ItemDataRole.UserRole + 1) or "",
                     "size": item1.text() if item1 else "",
                     "status": item2.text() if item2 else "",
@@ -2885,8 +2891,9 @@ class MainWindow(QMainWindow):
         data = {
             "row": row,
             "item": item_0,
-            "url": item_0.data(Qt.ItemDataRole.UserRole),
-            "path": item_0.data(Qt.ItemDataRole.UserRole + 1),
+            "url": item_0.data(Qt.ItemDataRole.UserRole) or "",
+            "referer": item_0.data(Qt.ItemDataRole.UserRole + 15) or item_0.data(Qt.ItemDataRole.UserRole) or "",
+            "path": item_0.data(Qt.ItemDataRole.UserRole + 1) or "",
             "filename": item_0.text(),
             "status": self.download_table.item(row, 2).text(),
             "size": self.download_table.item(row, 1).text(),
@@ -2970,10 +2977,11 @@ class MainWindow(QMainWindow):
 
     def process_incoming_url(self, data, allow_duplicate=False):
         """Fetches file info and shows the popup without stealing focus for main window"""
-        parts = data.split("|", 2)
+        parts = data.split("|", 3)
         url = parts[0]
         user_agent = parts[1] if len(parts) > 1 else ""
         cookies = parts[2] if len(parts) > 2 else ""
+        referrer = parts[3] if len(parts) > 3 else ""
 
         if not url:
             return
@@ -3037,7 +3045,7 @@ class MainWindow(QMainWindow):
 
         # 4. Start the fetcher
         from core.workers import FileInfoFetcherWorker
-        fetcher = FileInfoFetcherWorker(url, user_agent=user_agent, cookies=cookies)
+        fetcher = FileInfoFetcherWorker(url, user_agent=user_agent, cookies=cookies, referrer=referrer)
         self.active_fetchers.append(fetcher)
         
         # Connect to a wrapper that cleans up the thread memory when done
@@ -3194,7 +3202,8 @@ class MainWindow(QMainWindow):
                 start_paused=False,
                 show_dialog=show_prog,
                 user_agent=file_info.get("user_agent"),
-                cookies=file_info.get("cookies")
+                cookies=file_info.get("cookies"),
+                referer=file_info.get("referer") or file_info.get("url")
             )
             return
 
@@ -3251,7 +3260,8 @@ class MainWindow(QMainWindow):
             start_paused=True,
             show_dialog=False,
             user_agent=file_info.get("user_agent"),
-            cookies=file_info.get("cookies")
+            cookies=file_info.get("cookies"),
+            referer=file_info.get("referer") or file_info.get("url")
         )
         
         # Track the dialog to prevent garbage collection and allow cleanup
@@ -3293,7 +3303,9 @@ class MainWindow(QMainWindow):
                 resume_filename=results["filename"],
                 custom_save_dir=os.path.dirname(results["save_path"]),
                 show_dialog=show_prog,
-                user_agent=file_info.get("user_agent")
+                user_agent=file_info.get("user_agent"),
+                cookies=file_info.get("cookies"),
+                referrer=file_info.get("referer") or item_ref.data(Qt.ItemDataRole.UserRole + 15)
             )
         elif results["action"] == 'later':
             self._set_status_text(row, "Paused")
@@ -3308,7 +3320,7 @@ class MainWindow(QMainWindow):
             self.download_table.removeRow(row)
         self.save_data()
 
-    def start_download(self, url, custom_filename=None, custom_save_dir=None, size_data=None, start_paused=False, show_dialog=True, user_agent=None, cookies=None):
+    def start_download(self, url, custom_filename=None, custom_save_dir=None, size_data=None, start_paused=False, show_dialog=True, user_agent=None, cookies=None, referer=None):
         sorting_was_enabled = self.download_table.isSortingEnabled()
         self.download_table.setSortingEnabled(False)
 
@@ -3331,12 +3343,13 @@ class MainWindow(QMainWindow):
         item_name.setData(Qt.ItemDataRole.UserRole, url)
         item_name.setIcon(get_file_icon(filename_guess))
         
-        # Store raw timestamp data and cookies in the item
+        # Store raw timestamp data, cookies, and referer in the item
         item_name.setData(Qt.ItemDataRole.UserRole + 3, current_ts) # Date Added
         item_name.setData(Qt.ItemDataRole.UserRole + 2, current_ts) # Last Try
         item_name.setData(Qt.ItemDataRole.UserRole + 4, user_agent) # User-Agent
         item_name.setData(Qt.ItemDataRole.UserRole + 5, cookies)    # Cookies
         item_name.setData(Qt.ItemDataRole.UserRole + 8, "Main download queue")  # Queue
+        item_name.setData(Qt.ItemDataRole.UserRole + 15, referer or url)  # Referer
         
         # Determine explicit metadata bindings
         size_str = size_data[0] if size_data else "?"
@@ -3375,7 +3388,7 @@ class MainWindow(QMainWindow):
         
         if not start_paused:
             if len(self.active_downloads) < self.MAX_CONCURRENT_DOWNLOADS:
-                self._start_download_worker(url, item_name, resume_filename=filename_guess, custom_save_dir=save_dir, show_dialog=show_dialog, user_agent=user_agent, cookies=cookies)
+                self._start_download_worker(url, item_name, resume_filename=filename_guess, custom_save_dir=save_dir, show_dialog=show_dialog, user_agent=user_agent, cookies=cookies, referrer=referer or url)
             else:
                 # Slot full — mark as queued; _try_start_queued will pick it up
                 self._set_status_text(row, "Queued")
@@ -3383,11 +3396,13 @@ class MainWindow(QMainWindow):
         self.save_data()
         return item_name
 
-    def _start_download_worker(self, url, item_ref, resume_filename=None, custom_save_dir=None, show_dialog=True, user_agent=None, cookies=None, allow_resume=True):
+    def _start_download_worker(self, url, item_ref, resume_filename=None, custom_save_dir=None, show_dialog=True, user_agent=None, cookies=None, referrer=None, allow_resume=True):
         if not user_agent:
             user_agent = item_ref.data(Qt.ItemDataRole.UserRole + 4)
         if not cookies:
             cookies = item_ref.data(Qt.ItemDataRole.UserRole + 5)
+        if not referrer:
+            referrer = item_ref.data(Qt.ItemDataRole.UserRole + 15) or url
         
         config = load_category_config()
         categories = config.get("categories", {})
@@ -3438,12 +3453,14 @@ class MainWindow(QMainWindow):
             worker = Aria2Worker(
                 url, item_ref.row(), save_dir, resume_filename,
                 user_agent=user_agent, cookies=cookies, temp_dir=temp_dir,
+                referrer=referrer,
                 allow_resume=allow_resume
             )
         else:
             worker = DownloadWorker(
                 url, item_ref.row(), save_dir, resume_filename,
                 user_agent=user_agent, cookies=cookies, temp_dir=temp_dir,
+                referrer=referrer,
                 allow_resume=allow_resume
             )
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1952,6 +1952,37 @@ def test_toolbar_resume_disabled_when_already_resuming(qapp, monkeypatch, tmp_pa
     win.close()
 
 
+def test_properties_dialog_referer(qapp, tmp_path):
+    from ui.dialogs.properties import PropertiesDialog
+    from PyQt6.QtWidgets import QLineEdit
+
+    direct_url = "https://release-assets.githubusercontent.com/github-production-release-asset/1083868986/0562723c-f190-4894-b57c-2b2b2c955bfd?sp=r"
+    referer_url = "https://github.com/andrewginns/chromium-browser-snapshots-AndroidDesktop_arm64/releases/download/1687988/ChromePublic.apk"
+
+    file_data = {
+        "filename": "ChromePublic.apk",
+        "url": direct_url,
+        "referer": referer_url,
+        "path": str(tmp_path / "ChromePublic.apk"),
+        "status": "Complete",
+        "size": "388.45 MB",
+        "date_added": "2026-08-29 09:00:00",
+        "last_try": "2026-08-29 09:05:00"
+    }
+
+    dlg = PropertiesDialog(file_data)
+    dlg.hide()
+
+    line_edits = dlg.findChildren(QLineEdit)
+    texts = [le.text() for le in line_edits]
+
+    assert direct_url in texts
+    assert referer_url in texts
+
+    dlg.close()
+
+
+
 
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,10 +33,43 @@ def test_is_media_downloader_url():
     assert is_media_downloader_url("") is False
 
 def test_resolve_filename():
+    # 1. Standard URL with MIME type
     url = "http://example.com/testfile.mp4"
     headers = {"Content-Type": "video/mp4"}
-    filename = resolve_filename(url, headers)
-    assert filename == "testfile.mp4"
+    assert resolve_filename(url, headers) == "testfile.mp4"
+
+    # 2. GitHub APK Release URL with Content-Disposition & Android APK MIME
+    apk_url = "https://github.com/andrewginns/chromium-browser-snapshots-AndroidDesktop_arm64/releases/download/1687988/ChromePublic.apk"
+    apk_headers = {
+        "Content-Disposition": "attachment; filename=ChromePublic.apk",
+        "Content-Type": "application/vnd.android.package-archive"
+    }
+    assert resolve_filename(apk_url, apk_headers) == "ChromePublic.apk"
+    assert resolve_filename(apk_url, {}) == "ChromePublic.apk"
+
+    # 3. Azure/S3 Redirect URL with UUID path and response-content-disposition query parameter
+    redirect_url = "https://release-assets.githubusercontent.com/github-production-release-asset/1083868986/0562723c-f190-4894-b57c-2b2b2c955bfd?sp=r&response-content-disposition=attachment%3B%20filename%3DChromePublic.apk"
+    assert resolve_filename(redirect_url, {}) == "ChromePublic.apk"
+
+    # 4. Unknown MIME type with filename in URL path (must download as-is)
+    unknown_mime_url = "https://example.com/builds/app_binary.customext"
+    assert resolve_filename(unknown_mime_url, {"Content-Type": "application/x-custom-unknown-type"}) == "app_binary.customext"
+
+    # 5. Unknown MIME type with Content-Disposition
+    cd_unknown_url = "https://example.com/api/v1/download?id=4928"
+    cd_unknown_headers = {
+        "Content-Disposition": "attachment; filename=\"special_package.pkgx\"",
+        "Content-Type": "application/x-unknown-mimetype"
+    }
+    assert resolve_filename(cd_unknown_url, cd_unknown_headers) == "special_package.pkgx"
+
+    # 6. Fallback when neither URL nor headers provide a filename
+    api_url = "https://example.com/api/get/987654321"
+    assert resolve_filename(api_url, {"Content-Type": "application/x-unknown-mimetype"}) == "downloaded_file"
+
+    # 7. Script extension replacement with recognized MIME
+    script_url = "https://example.com/get.php?id=1"
+    assert resolve_filename(script_url, {"Content-Type": "application/pdf"}) == "get.pdf"
 
 def test_parse_size_to_bytes():
     assert parse_size_to_bytes("1.50 MB") == int(1.50 * 1024 * 1024)


### PR DESCRIPTION
## Summary
- **Filename Resolution**: Fixed `NameError: name 'mimetypes' is not defined` in `resolve_filename` and added robust Content-Disposition & cloud storage query parameter extraction (`response-content-disposition`, `rscd`, `filename`).
- **MIME Map & Unknown MIME Safety**: Added Android APK (`application/vnd.android.package-archive` -> `.apk`) and archive/media formats; safely preserve original filenames/extensions for unknown MIME types.
- **Referer Field**: Added `Referer:` field below `Address:` in download Properties dialog, with end-to-end data flow through IPC, pre-fetcher, workers, and database.

## Verification
- All automated unit tests passed: `pytest -v tests/` (169/169 passed).
- Added `test_resolve_filename` edge cases in `tests/test_utils.py`.
- Added `test_properties_dialog_referer` in `tests/test_ui.py`.