### PR TITLE
feat(extension): Facebook video resolution detection, startup transparency, and manifest v0.6

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -10,7 +10,7 @@ Bengal Download Manager targets multiple distribution channels:
 * **Canonical Snap Store**: Snap package built via Snapcraft (`snap/snapcraft.yaml`).
 * **Flatpak / Flathub**: Flatpak bundle and AppStream catalog metadata (`flatpak/io.github.tazihad.bengal-download-manager.metainfo.xml`).
 * **In-App Runtime**: Help -> About Dialog, CLI `--version`, and IPC daemon (`src/core/version.py`).
-* *(Note: Browser extension in `extension/manifest.json` is versioned independently, e.g. `0.5`).*
+* *(Note: Browser extension in `extension/manifest.json` is versioned independently, e.g. `0.6`).*
 
 ### The Canonical File
 The root file **`VERSION`** is the single authoritative source of truth for the application version. No other file should be edited manually to change versions.

--- a/extension/background.js
+++ b/extension/background.js
@@ -635,7 +635,7 @@ const pendingMediaRequests = new Map(); // requestId -> { url, method, requestHe
 const detectedMediaUrls = new Map();    // url -> timestamp (5-second deduplication)
 const tabMediaStreams = new Map();      // tabId -> Array of { url, contentType, title, timestamp }
 
-function recordSniffedMedia(tabId, url, contentType, title) {
+function recordSniffedMedia(tabId, url, contentType, title, sizeBytes = 0) {
   if (!tabId || tabId === -1 || !url) return;
   let list = tabMediaStreams.get(tabId);
   if (!list) {
@@ -646,9 +646,10 @@ function recordSniffedMedia(tabId, url, contentType, title) {
   if (existing) {
     if (title && !existing.title) existing.title = title;
     if (contentType && !existing.contentType) existing.contentType = contentType;
+    if (sizeBytes && !existing.sizeBytes) existing.sizeBytes = sizeBytes;
     existing.timestamp = Date.now();
   } else {
-    list.push({ url, contentType: contentType || "", title: title || "", timestamp: Date.now() });
+    list.push({ url, contentType: contentType || "", title: title || "", sizeBytes: sizeBytes || 0, timestamp: Date.now() });
     if (list.length > 30) list.shift();
   }
 }
@@ -858,11 +859,16 @@ async function postMediaToBengalDM(details, req, tab) {
 
   // 1. Record sniffed media for this tab so the on-page floating popup can offer it
   if (details.tabId && details.tabId !== -1) {
-    recordSniffedMedia(details.tabId, details.url, "", tab ? tab.title : "");
+    let cl = 0;
+    if (details.responseHeaders) {
+      const clH = details.responseHeaders.find(h => (h.name || '').toLowerCase() === 'content-length');
+      if (clH) cl = parseInt(clH.value, 10) || 0;
+    }
+    recordSniffedMedia(details.tabId, details.url, "", tab ? tab.title : "", cl);
     try {
       chrome.tabs.sendMessage(details.tabId, {
         action: "media_stream_detected",
-        stream: { url: details.url, title: tab ? tab.title : "" }
+        stream: { url: details.url, title: tab ? tab.title : "", sizeBytes: cl }
       }).catch(() => {});
     } catch (e) {}
   }
@@ -899,6 +905,7 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
 
     let contentType = "";
     let isAttachment = false;
+    let contentLength = 0;
 
     for (const h of (details.responseHeaders || [])) {
       const name = (h.name || '').toLowerCase();
@@ -907,6 +914,9 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
         contentType = val;
       } else if (name === 'content-disposition' && (val.includes('attachment') || val.includes('filename='))) {
         isAttachment = true;
+      } else if (name === 'content-length') {
+        const cl = parseInt(val, 10);
+        if (!isNaN(cl) && cl > 0) contentLength = cl;
       }
     }
 
@@ -928,11 +938,11 @@ if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
           if (tab.url && matchesUrlOrDomain(tab.url, cachedFilterRules.blacklistUrls)) {
             return;
           }
-          recordSniffedMedia(details.tabId, details.url, contentType, tab.title || "");
+          recordSniffedMedia(details.tabId, details.url, contentType, tab.title || "", contentLength);
           try {
             chrome.tabs.sendMessage(details.tabId, {
               action: "media_stream_detected",
-              stream: { url: details.url, contentType: contentType }
+              stream: { url: details.url, contentType: contentType, sizeBytes: contentLength }
             }).catch(() => {});
           } catch (e) {}
           postMediaToBengalDM(details, req, tab, contentType);

--- a/extension/background.js
+++ b/extension/background.js
@@ -987,6 +987,19 @@ if (chrome.tabs && chrome.tabs.onUpdated) {
   });
 }
 
+// 5. Close media popup dropdown when switching tabs or window focus
+if (chrome.tabs && chrome.tabs.onActivated) {
+  chrome.tabs.onActivated.addListener((activeInfo) => {
+    chrome.tabs.query({}, (tabs) => {
+      for (const t of (tabs || [])) {
+        if (t.id && t.id !== activeInfo.tabId) {
+          chrome.tabs.sendMessage(t.id, { action: "close_dropdown" }).catch(() => {});
+        }
+      }
+    });
+  });
+}
+
 // --- HTTP REQUEST & RESPONSE MONITORING SYSTEM (IDM Integration Module Style) ---
 if (chrome.webRequest && chrome.webRequest.onHeadersReceived) {
   const setupListener = (extraSpec) => {

--- a/extension/content.js
+++ b/extension/content.js
@@ -17,6 +17,7 @@
   let userCoords = { left: 0, top: 0 };
   let isDropdownOpen = false;
   let ytMediaInfo = null;
+  let platformMediaInfo = null;
   const dismissedVideos = new Set();
   let activeIframeVideo = null;
   let activeIframeData = null;
@@ -319,10 +320,11 @@
     }
   } catch (e) {}
 
-  // Listen for media info from main world
+  // Listen for media info from main world (Universal Media & Resolution Bridge)
   window.addEventListener('message', (event) => {
     if (event.source !== window || !event.data) return;
     if (event.data.type === '__BDM_MEDIA_INFO__' && event.data.data) {
+      platformMediaInfo = event.data.data;
       ytMediaInfo = event.data.data;
       if (activeVideo && isDropdownOpen) {
         populateDropdown();
@@ -484,6 +486,14 @@
   // Request fresh media info periodically
   function requestMediaInfo() {
     if (isSiteBlacklisted()) return;
+    if (activeVideo && activeVideo.tagName === 'VIDEO') {
+      try {
+        document.querySelectorAll('video[data-bdm-active="true"]').forEach(v => {
+          if (v !== activeVideo) delete v.dataset.bdmActive;
+        });
+        activeVideo.dataset.bdmActive = 'true';
+      } catch (e) {}
+    }
     try {
       window.postMessage({ type: '__BDM_GET_MEDIA_INFO__' }, '*');
     } catch (e) {}
@@ -1390,8 +1400,8 @@
       if (host.includes('tiktok.com')) {
         return path.includes('/video/') || path.includes('/v/') || /\/\d{18,20}/.test(path);
       }
-      if (host.includes('facebook.com')) {
-        return path.includes('/reel/') || path.includes('/watch') || path.includes('/videos/') || u.searchParams.has('v');
+      if (host.includes('facebook.com') || host.includes('fb.watch') || host.includes('fb.com')) {
+        return path.includes('/reel/') || path.includes('/watch') || path.includes('/videos/') || u.searchParams.has('v') || path.includes('/story.php') || u.searchParams.has('story_fbid') || path.includes('/posts/') || path.includes('/permalink/');
       }
       if (host.includes('instagram.com')) {
         return path.includes('/reel/') || path.includes('/p/') || path.includes('/tv/') || path.includes('/reels/');
@@ -1420,14 +1430,24 @@
 
     // Facebook & Reels
     if (host.includes('facebook.com') || host.includes('fb.watch') || host.includes('fb.com')) {
+      // 1. Exact canonical link if platformMediaInfo (React Fiber) extracted videoFBID
+      if (platformMediaInfo && platformMediaInfo.platform === 'facebook' && platformMediaInfo.videoId) {
+        return `https://www.facebook.com/watch/?v=${platformMediaInfo.videoId}`;
+      }
       if (isCanonicalMediaPage(currentUrl)) {
         return currentUrl;
       }
       if (video) {
         try {
-          const container = video.closest('[role="article"], [data-pagelet*="FeedUnit"], [data-pagelet*="Reel"], div[role="main"]') || video.parentElement;
+          if (video.dataset && video.dataset.videoFbid) {
+            return `https://www.facebook.com/watch/?v=${video.dataset.videoFbid}`;
+          }
+          const container = video.closest('[role="article"], [data-pagelet*="FeedUnit"], [data-pagelet*="Reel"], div[role="main"], div[data-video-id]') || video.parentElement;
           if (container) {
-            const permalinkEl = container.querySelector('a[href*="/reel/"], a[href*="/watch"], a[href*="/videos/"]');
+            if (container.dataset && container.dataset.videoId) {
+              return `https://www.facebook.com/watch/?v=${container.dataset.videoId}`;
+            }
+            const permalinkEl = container.querySelector('a[href*="/reel/"], a[href*="/watch"], a[href*="/videos/"], a[href*="/posts/"], a[href*="/permalink/"]');
             if (permalinkEl && permalinkEl.href && isCanonicalMediaPage(permalinkEl.href)) {
               return permalinkEl.href;
             }
@@ -1801,14 +1821,16 @@
     return Math.round(durationSec * (bitrateKbps || 2500) * 125);
   }
 
-  // 9. Supported Resolutions Filtering (Never show unsupported qualities!)
+  // 9. Supported Resolutions Filtering (Preserves existing site logic + special Facebook IDM case)
   function getSupportedResolutions(video) {
     const isYouTube = window.location.hostname.includes('youtube.com');
-    const duration = (ytMediaInfo && ytMediaInfo.duration) ||
+    const isFacebook = window.location.hostname.includes('facebook.com') || window.location.hostname.includes('fb.watch') || window.location.hostname.includes('fb.com');
+    const duration = (platformMediaInfo && platformMediaInfo.duration) ||
+                     (ytMediaInfo && ytMediaInfo.duration) ||
                      (activeIframeData && activeIframeData.duration) ||
                      (video && video.duration) || 0;
 
-    // A. Check YouTube Player API Levels
+    // A. Check YouTube Player API Levels (Untouched)
     if (isYouTube && ytMediaInfo && Array.isArray(ytMediaInfo.levels) && ytMediaInfo.levels.length > 0) {
       const ytLevelMap = {
         'highres': { quality: '4K (2160p)', badge: '4K', label: '4K Ultra HD', height: 2160, bitrate: 22000, cls: 'uhd' },
@@ -1855,7 +1877,7 @@
       }
     }
 
-    // B. If an HLS (m3u8), DASH, or direct media stream was sniffed for this tab (only on generic sites)
+    // B. If an HLS (m3u8), DASH, or direct media stream was sniffed for this tab (only on generic sites - Untouched)
     const isPopular = isPopularMediaHost(window.location.hostname);
     if (!isPopular) {
       const masterStream = sniffedMediaStreams.find(s => s.url.includes('master.m3u8') || s.url.includes('master.mpd'));
@@ -1898,7 +1920,101 @@
       }
     }
 
-    // C. Standard Video Height Filtering (Generic sites or fallback)
+    // Special Facebook Case (IDM React Fiber & DASH Manifest Method)
+    if (isFacebook) {
+      const fbTiers = [
+        { quality: '2160p (4K)', badge: '4K', label: '4K Ultra HD', height: 2160, bitrate: 22000, cls: 'uhd' },
+        { quality: '1440p (2K)', badge: '2K', label: '2K Quad HD', height: 1440, bitrate: 12000, cls: 'uhd' },
+        { quality: '1080p', badge: '1080p', label: '1080p Full HD', height: 1080, bitrate: 5000, cls: 'hd' },
+        { quality: '720p', badge: '720p', label: '720p HD', height: 720, bitrate: 2500, cls: 'hd' },
+        { quality: '480p', badge: '480p', label: '480p SD', height: 480, bitrate: 1200, cls: '' },
+        { quality: '360p', badge: '360p', label: '360p', height: 360, bitrate: 700, cls: '' }
+      ];
+
+      // If Facebook React Fiber or DASH manifest extracted explicit resolution levels
+      if (platformMediaInfo && platformMediaInfo.platform === 'facebook' && Array.isArray(platformMediaInfo.resolutions) && platformMediaInfo.resolutions.length > 0) {
+        const seenQualities = new Set();
+        const result = [];
+        for (const h of platformMediaInfo.resolutions) {
+          let tier = fbTiers.find(t => t.height === h) ||
+                     fbTiers.find(t => Math.abs(t.height - h) <= 60);
+          if (!tier) {
+            const isHD = h >= 720;
+            tier = {
+              quality: `${h}p`,
+              badge: `${h}p`,
+              label: `${h}p ${isHD ? 'HD' : 'SD'}`,
+              height: h,
+              bitrate: h >= 1080 ? 5000 : (h >= 720 ? 2500 : 1200),
+              cls: isHD ? 'hd' : ''
+            };
+          }
+          if (!seenQualities.has(tier.quality)) {
+            seenQualities.add(tier.quality);
+            const item = {
+              ...tier,
+              sizeBytes: estimateFileSizeBytes(duration, tier.bitrate),
+              size: estimateFileSize(duration, tier.bitrate, false)
+            };
+            if (tier.height >= 720 && platformMediaInfo.hdUrl) item.streamUrl = platformMediaInfo.hdUrl;
+            else if (platformMediaInfo.sdUrl) item.streamUrl = platformMediaInfo.sdUrl;
+            result.push(item);
+          }
+        }
+        if (result.length > 0) {
+          result.push({
+            quality: 'Audio Only (MP3)',
+            badge: 'MP3',
+            label: 'Audio Only',
+            height: 0,
+            bitrate: 192,
+            cls: 'audio',
+            isAudio: true,
+            sizeBytes: estimateFileSizeBytes(duration, 192),
+            size: estimateFileSize(duration, 192, true)
+          });
+          return result;
+        }
+      }
+
+      // If Facebook video is HD or adaptive buffer hasn't reached full quality yet:
+      const rawVh = (activeIframeData && activeIframeData.videoHeight) || (video && video.videoHeight) || 0;
+      const rawVw = (activeIframeData && activeIframeData.videoWidth) || (video && video.videoWidth) || 0;
+      const vh = Math.max(rawVh, rawVw) || 720;
+      const isFbHD = (platformMediaInfo && platformMediaInfo.isHD) || vh >= 720;
+      const maxH = isFbHD ? Math.max(vh, 1080) : Math.max(vh, 480);
+
+      let filtered = fbTiers
+        .filter(t => t.height <= maxH)
+        .map(t => ({
+          ...t,
+          sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
+          size: estimateFileSize(duration, t.bitrate, false)
+        }));
+
+      if (filtered.length === 0) {
+        filtered = fbTiers.slice(2).map(t => ({
+          ...t,
+          sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
+          size: estimateFileSize(duration, t.bitrate, false)
+        }));
+      }
+
+      filtered.push({
+        quality: 'Audio Only (MP3)',
+        badge: 'MP3',
+        label: 'Audio Only',
+        height: 0,
+        bitrate: 192,
+        cls: 'audio',
+        isAudio: true,
+        sizeBytes: estimateFileSizeBytes(duration, 192),
+        size: estimateFileSize(duration, 192, true)
+      });
+      return filtered;
+    }
+
+    // C. Standard Video Height Filtering (Generic sites or fallback - Untouched for TikTok, Instagram, Twitter, etc.)
     const rawVh = (activeIframeData && activeIframeData.videoHeight) || (video && video.videoHeight) || 0;
     const rawVw = (activeIframeData && activeIframeData.videoWidth) || (video && video.videoWidth) || 0;
     // For vertical videos (TikTok, YouTube Shorts, Reels), use maximum dimension to preserve 720p/1080p options

--- a/extension/content.js
+++ b/extension/content.js
@@ -470,7 +470,11 @@
     }
     if (msg && msg.action === "media_stream_detected" && msg.stream) {
       if (!isAppConnected || !enableMediaSniffing || isSiteBlacklisted()) return;
-      if (!sniffedMediaStreams.some(s => s.url === msg.stream.url)) {
+      const existing = sniffedMediaStreams.find(s => s.url === msg.stream.url);
+      if (existing) {
+        if (msg.stream.sizeBytes && !existing.sizeBytes) existing.sizeBytes = msg.stream.sizeBytes;
+        if (msg.stream.contentType && !existing.contentType) existing.contentType = msg.stream.contentType;
+      } else {
         sniffedMediaStreams.unshift(msg.stream);
         if (sniffedMediaStreams.length > 30) sniffedMediaStreams.pop();
         if (activeVideo && isDropdownOpen) {
@@ -1804,21 +1808,53 @@
     return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
   }
 
+  function formatFileSize(bytes, isGuessed = false) {
+    if (!bytes || isNaN(bytes) || !isFinite(bytes) || bytes <= 0) {
+      return isGuessed ? "~ MB" : "";
+    }
+    const prefix = isGuessed ? "~ " : "";
+    if (bytes >= 1073741824) {
+      return prefix + (bytes / 1073741824).toFixed(1) + " GB";
+    } else if (bytes >= 1048576) {
+      return prefix + (bytes / 1048576).toFixed(1) + " MB";
+    } else if (bytes >= 1024) {
+      return prefix + (bytes / 1024).toFixed(0) + " KB";
+    } else {
+      return prefix + bytes + " B";
+    }
+  }
+
   function estimateFileSize(durationSec, bitrateKbps, isAudio) {
     if (!durationSec || isNaN(durationSec) || !isFinite(durationSec) || durationSec <= 0) return "~ MB";
     const bytes = durationSec * bitrateKbps * 125;
-    if (bytes >= 1073741824) {
-      return (bytes / 1073741824).toFixed(1) + " GB";
-    } else if (bytes >= 1048576) {
-      return (bytes / 1048576).toFixed(1) + " MB";
-    } else {
-      return (bytes / 1024).toFixed(0) + " KB";
-    }
+    return formatFileSize(bytes, true);
   }
 
   function estimateFileSizeBytes(durationSec, bitrateKbps) {
     if (!durationSec || isNaN(durationSec) || !isFinite(durationSec) || durationSec <= 0) return 0;
     return Math.round(durationSec * (bitrateKbps || 2500) * 125);
+  }
+
+  function findMatchingFileSizeBytes(streamUrl, video) {
+    if (streamUrl && Array.isArray(sniffedMediaStreams)) {
+      const found = sniffedMediaStreams.find(s => s.url === streamUrl && s.sizeBytes > 0);
+      if (found) return found.sizeBytes;
+    }
+    if (video && Array.isArray(sniffedMediaStreams)) {
+      const vSrc = video.currentSrc || video.src;
+      if (vSrc) {
+        const found = sniffedMediaStreams.find(s => s.url === vSrc && s.sizeBytes > 0);
+        if (found) return found.sizeBytes;
+      }
+    }
+    if (activeIframeData && Array.isArray(sniffedMediaStreams)) {
+      const iSrc = activeIframeData.streamUrl || activeIframeData.currentSrc;
+      if (iSrc) {
+        const found = sniffedMediaStreams.find(s => s.url === iSrc && s.sizeBytes > 0);
+        if (found) return found.sizeBytes;
+      }
+    }
+    return 0;
   }
 
   // 9. Supported Resolutions Filtering (Preserves existing site logic + special Facebook IDM case)
@@ -1892,6 +1928,9 @@
         const resCls = vh >= 720 ? 'hd' : '';
         const tag = m3u8Stream ? '(HLS Stream)' : '(Media Stream)';
 
+        const exactFileBytes = findMatchingFileSizeBytes(streamCandidate.url, video) || (streamCandidate.sizeBytes > 0 ? streamCandidate.sizeBytes : 0);
+        const hasExactFile = exactFileBytes > 0;
+
         return [
           {
             quality: `${resBadge} ${tag}`,
@@ -1901,8 +1940,8 @@
             bitrate: vh >= 1080 ? 5000 : 2500,
             cls: resCls,
             streamUrl: streamCandidate.url,
-            sizeBytes: estimateFileSizeBytes(duration, vh >= 1080 ? 5000 : 2500),
-            size: estimateFileSize(duration, vh >= 1080 ? 5000 : 2500, false)
+            sizeBytes: hasExactFile ? exactFileBytes : estimateFileSizeBytes(duration, vh >= 1080 ? 5000 : 2500),
+            size: hasExactFile ? formatFileSize(exactFileBytes, false) : estimateFileSize(duration, vh >= 1080 ? 5000 : 2500, false)
           },
           {
             quality: 'Audio Only (MP3)',
@@ -1958,6 +1997,12 @@
             };
             if (tier.height >= 720 && platformMediaInfo.hdUrl) item.streamUrl = platformMediaInfo.hdUrl;
             else if (platformMediaInfo.sdUrl) item.streamUrl = platformMediaInfo.sdUrl;
+
+            const exactBytes = findMatchingFileSizeBytes(item.streamUrl, video);
+            if (exactBytes > 0) {
+              item.sizeBytes = exactBytes;
+              item.size = formatFileSize(exactBytes, false);
+            }
             result.push(item);
           }
         }
@@ -1983,21 +2028,28 @@
       const vh = Math.max(rawVh, rawVw) || 720;
       const isFbHD = (platformMediaInfo && platformMediaInfo.isHD) || vh >= 720;
       const maxH = isFbHD ? Math.max(vh, 1080) : Math.max(vh, 480);
+      const exactFbBytes = findMatchingFileSizeBytes(null, video);
 
       let filtered = fbTiers
         .filter(t => t.height <= maxH)
-        .map(t => ({
-          ...t,
-          sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
-          size: estimateFileSize(duration, t.bitrate, false)
-        }));
+        .map(t => {
+          const hasExact = exactFbBytes > 0 && t.height === vh;
+          return {
+            ...t,
+            sizeBytes: hasExact ? exactFbBytes : estimateFileSizeBytes(duration, t.bitrate),
+            size: hasExact ? formatFileSize(exactFbBytes, false) : estimateFileSize(duration, t.bitrate, false)
+          };
+        });
 
       if (filtered.length === 0) {
-        filtered = fbTiers.slice(2).map(t => ({
-          ...t,
-          sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
-          size: estimateFileSize(duration, t.bitrate, false)
-        }));
+        filtered = fbTiers.slice(2).map(t => {
+          const hasExact = exactFbBytes > 0 && t.height === vh;
+          return {
+            ...t,
+            sizeBytes: hasExact ? exactFbBytes : estimateFileSizeBytes(duration, t.bitrate),
+            size: hasExact ? formatFileSize(exactFbBytes, false) : estimateFileSize(duration, t.bitrate, false)
+          };
+        });
       }
 
       filtered.push({
@@ -2028,22 +2080,30 @@
       { quality: '360p', badge: '360p', label: '360p', height: 360, bitrate: 700, cls: '' }
     ];
 
+    const exactVideoBytes = findMatchingFileSizeBytes(null, video);
+
     // Strictly filter out any resolution tier higher than the video's actual dimensions
     let filtered = allTiers
       .filter(t => t.height <= vh)
-      .map(t => ({
-        ...t,
-        sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
-        size: estimateFileSize(duration, t.bitrate, false)
-      }));
+      .map((t, idx) => {
+        const hasExact = exactVideoBytes > 0 && (t.height === vh || idx === 0);
+        return {
+          ...t,
+          sizeBytes: hasExact ? exactVideoBytes : estimateFileSizeBytes(duration, t.bitrate),
+          size: hasExact ? formatFileSize(exactVideoBytes, false) : estimateFileSize(duration, t.bitrate, false)
+        };
+      });
 
     // If dimensions check was overly strict or metadata not ready, provide standard tiers (1080p, 720p, 480p, 360p)
     if (filtered.length === 0) {
-      filtered = allTiers.slice(2).map(t => ({
-        ...t,
-        sizeBytes: estimateFileSizeBytes(duration, t.bitrate),
-        size: estimateFileSize(duration, t.bitrate, false)
-      }));
+      filtered = allTiers.slice(2).map((t, idx) => {
+        const hasExact = exactVideoBytes > 0 && (t.height === vh || idx === 0);
+        return {
+          ...t,
+          sizeBytes: hasExact ? exactVideoBytes : estimateFileSizeBytes(duration, t.bitrate),
+          size: hasExact ? formatFileSize(exactVideoBytes, false) : estimateFileSize(duration, t.bitrate, false)
+        };
+      });
     }
 
     // Add Audio Option

--- a/extension/content.js
+++ b/extension/content.js
@@ -590,7 +590,7 @@
       font-variant-numeric: tabular-nums;
       pointer-events: auto;
       z-index: 2147483647;
-      opacity: 0.95;
+      opacity: 0.35;
       transition: opacity 0.25s ease, transform 0.2s ease;
     }
 
@@ -599,7 +599,7 @@
     }
 
     .bdm-root.idle {
-      opacity: 0.4;
+      opacity: 0.35;
     }
 
     /* If hovered, active, open, or dragging, show up completely */

--- a/extension/content.js
+++ b/extension/content.js
@@ -451,6 +451,12 @@
   } catch {}
 
   chrome.runtime.onMessage.addListener((msg) => {
+    if (msg && msg.action === "close_dropdown") {
+      if (isDropdownOpen) {
+        closeDropdown();
+      }
+      return;
+    }
     if (msg && msg.action === "connection_status_changed") {
       const wasConnected = isAppConnected;
       isAppConnected = Boolean(msg.online);
@@ -2500,11 +2506,45 @@
     resetIdleTimer();
   }
 
-  // Close dropdown on outside click
-  document.addEventListener('click', (e) => {
-    if (Date.now() - lastOpenedTime < 350) return;
+  // Close dropdown on outside click or pointerdown
+  function handleOutsideInteraction(e) {
+    if (!isDropdownOpen) return;
+    if (Date.now() - lastOpenedTime < 100) return;
     const path = e.composedPath ? e.composedPath() : [];
-    if (isDropdownOpen && !path.includes(host) && !host.contains(e.target)) {
+    if (path.includes(host) || path.includes(root) || (host && host.contains(e.target))) {
+      return;
+    }
+    closeDropdown();
+  }
+
+  // Use capture phase on both window and document to guarantee receiving events even if the site stops propagation
+  window.addEventListener('click', handleOutsideInteraction, true);
+  document.addEventListener('click', handleOutsideInteraction, true);
+  window.addEventListener('pointerdown', handleOutsideInteraction, true);
+  document.addEventListener('pointerdown', handleOutsideInteraction, true);
+
+  // Close dropdown on Escape key
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isDropdownOpen) {
+      closeDropdown();
+    }
+  }, true);
+
+  // Close dropdown when switching to another tab or window loses focus
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden && isDropdownOpen) {
+      closeDropdown();
+    }
+  });
+
+  window.addEventListener('blur', () => {
+    if (isDropdownOpen) {
+      closeDropdown();
+    }
+  });
+
+  window.addEventListener('pagehide', () => {
+    if (isDropdownOpen) {
       closeDropdown();
     }
   });

--- a/extension/inject.js
+++ b/extension/inject.js
@@ -1,5 +1,9 @@
-// Bengal DM - YouTube & HTML5 Media Bridge (Main World)
+// Bengal DM - YouTube & Facebook Media Bridge (Main World)
 (function() {
+  const host = window.location.hostname.toLowerCase();
+  const isFacebook = host.includes('facebook.com') || host.includes('fb.watch') || host.includes('fb.com');
+
+  // --- YouTube Media Info (Preserved as is) ---
   function getYouTubeMediaInfo() {
     try {
       const player = document.getElementById('movie_player') || document.querySelector('.html5-video-player');
@@ -29,9 +33,224 @@
     }
   }
 
+  // --- Facebook Media & Resolution Detection (Special Facebook Case - IDM Method) ---
+  let fbMetadataCache = new Map(); // videoId -> metadata
+
+  function parseDashManifestHeights(xmlText) {
+    if (!xmlText || typeof xmlText !== 'string' || !xmlText.includes('<Representation')) return null;
+    const heights = new Set();
+    const heightRegex = /height=["'](\d+)["']/gi;
+    let match;
+    while ((match = heightRegex.exec(xmlText)) !== null) {
+      const h = parseInt(match[1], 10);
+      if (h && h >= 144 && h <= 4320) heights.add(h);
+    }
+    if (heights.size === 0) return null;
+    return Array.from(heights).sort((a, b) => b - a);
+  }
+
+  function getReactFiber(element) {
+    if (!element) return null;
+    for (const key of Object.keys(element)) {
+      if (key.startsWith('__reactFiber$') || key.startsWith('__reactInternalInstance$')) {
+        return element[key];
+      }
+    }
+    return null;
+  }
+
+  // Only hook network calls if on Facebook
+  if (isFacebook) {
+    // Intercept Facebook GraphQL responses for video metadata & DASH manifests
+    function inspectFacebookResponse(url, text) {
+      if (!text || typeof text !== 'string') return;
+      if (text.includes('dash_manifest') || url.includes('/api/graphql/')) {
+        try {
+          const json = JSON.parse(text);
+          const queue = [json];
+          let depth = 0;
+          while (queue.length > 0 && depth < 100) {
+            depth++;
+            const curr = queue.shift();
+            if (!curr || typeof curr !== 'object') continue;
+
+            if (typeof curr.dash_manifest === 'string') {
+              const heights = parseDashManifestHeights(curr.dash_manifest);
+              const vId = curr.id || curr.video_id || curr.videoFBID;
+              if (heights && vId) {
+                fbMetadataCache.set(String(vId), {
+                  resolutions: heights,
+                  maxHeight: heights[0],
+                  isHD: heights.some(h => h >= 720),
+                  hdUrl: curr.playable_url_quality_hd || curr.browser_native_hd_url,
+                  sdUrl: curr.playable_url_quality_sd || curr.browser_native_sd_url
+                });
+              }
+            }
+            for (const k of Object.keys(curr)) {
+              if (curr[k] && typeof curr[k] === 'object') queue.push(curr[k]);
+            }
+          }
+        } catch (e) {}
+      }
+    }
+
+    if (typeof window.fetch === 'function') {
+      const origFetch = window.fetch;
+      window.fetch = function(...args) {
+        const promise = origFetch.apply(this, args);
+        try {
+          const url = (args[0] instanceof Request) ? args[0].url : String(args[0] || '');
+          if (url.includes('/api/graphql/') || url.includes('video') || url.includes('manifest')) {
+            promise.then(response => {
+              try {
+                if (response && response.ok) {
+                  const clone = response.clone();
+                  clone.text().then(text => inspectFacebookResponse(url, text)).catch(() => {});
+                }
+              } catch (e) {}
+            }).catch(() => {});
+          }
+        } catch (e) {}
+        return promise;
+      };
+    }
+
+    if (typeof window.XMLHttpRequest === 'function') {
+      const origOpen = XMLHttpRequest.prototype.open;
+      const origSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function(method, url, ...rest) {
+        this.__bdm_url = String(url || '');
+        return origOpen.apply(this, [method, url, ...rest]);
+      };
+      XMLHttpRequest.prototype.send = function(...args) {
+        const url = this.__bdm_url;
+        if (url && (url.includes('/api/graphql/') || url.includes('video'))) {
+          this.addEventListener('load', function() {
+            try {
+              if (this.status >= 200 && this.status < 300 && this.responseText) {
+                inspectFacebookResponse(url, this.responseText);
+              }
+            } catch (e) {}
+          });
+        }
+        return origSend.apply(this, args);
+      };
+    }
+  }
+
+  function getFacebookMediaInfo(video) {
+    if (!video) return null;
+    let videoFBID = null;
+    let dashManifest = null;
+    let isHD = false;
+    let dimensions = null;
+    let hdUrl = null;
+    let sdUrl = null;
+    let duration = video.duration || 0;
+
+    try {
+      // Traverse React Fiber nodes up to 15 levels (the exact IDM coreVideoPlayerMetaData pattern)
+      let curr = video;
+      for (let depth = 0; depth < 15 && curr; depth++) {
+        const fiber = getReactFiber(curr);
+        if (fiber) {
+          let f = fiber;
+          for (let fDepth = 0; fDepth < 12 && f; fDepth++) {
+            const props = f.memoizedProps;
+            if (props) {
+              const meta = props.coreVideoPlayerMetaData ||
+                           (props.videoPlayerConfig && props.videoPlayerConfig.coreVideoPlayerMetaData) ||
+                           (props.videoData && props.videoData.coreVideoPlayerMetaData);
+
+              if (meta) {
+                if (meta.videoFBID) videoFBID = String(meta.videoFBID);
+                if (meta.dash_manifest || meta.dashManifest) dashManifest = meta.dash_manifest || meta.dashManifest;
+                if (meta.isHD || meta.hdSrc || meta.playableUrlQualityHD || meta.playable_url_quality_hd) isHD = true;
+                if (meta.hdSrc || meta.playableUrlQualityHD || meta.playable_url_quality_hd) {
+                  hdUrl = meta.hdSrc || meta.playableUrlQualityHD || meta.playable_url_quality_hd;
+                }
+                if (meta.sdSrc || meta.playableUrlQualitySD || meta.playable_url_quality_sd) {
+                  sdUrl = meta.sdSrc || meta.playableUrlQualitySD || meta.playable_url_quality_sd;
+                }
+                if (meta.dimensions) dimensions = meta.dimensions;
+                if (meta.duration && !duration) duration = meta.duration;
+                break;
+              }
+
+              if (props.videoFBID && !videoFBID) videoFBID = String(props.videoFBID);
+              if (props.video_id && !videoFBID) videoFBID = String(props.video_id);
+              if (props.playableUrlQualityHD || props.playable_url_quality_hd || props.hdSrc) isHD = true;
+            }
+            f = f.return;
+          }
+        }
+        if (videoFBID && (dashManifest || isHD)) break;
+        curr = curr.parentElement;
+      }
+    } catch (e) {}
+
+    // Check cached network metadata if videoFBID was found
+    let parsedHeights = null;
+    if (dashManifest) {
+      parsedHeights = parseDashManifestHeights(dashManifest);
+    } else if (videoFBID && fbMetadataCache.has(videoFBID)) {
+      const cached = fbMetadataCache.get(videoFBID);
+      parsedHeights = cached.resolutions;
+      if (cached.isHD) isHD = true;
+      if (cached.hdUrl && !hdUrl) hdUrl = cached.hdUrl;
+      if (cached.sdUrl && !sdUrl) sdUrl = cached.sdUrl;
+    }
+
+    const resSet = new Set();
+    if (Array.isArray(parsedHeights)) {
+      parsedHeights.forEach(h => resSet.add(h));
+      if (parsedHeights.some(h => h >= 720)) isHD = true;
+    }
+
+    const dimHeight = (dimensions && (dimensions.height || dimensions.videoHeight)) ||
+                      Math.max(video.videoHeight, video.videoWidth) || 0;
+    if (dimHeight >= 720) isHD = true;
+
+    // Ensure full tiers if HD is detected
+    if (isHD || dimHeight >= 720) {
+      if (dimHeight >= 1080 || !dimHeight) resSet.add(1080);
+      resSet.add(720);
+      resSet.add(480);
+      resSet.add(360);
+    } else if (resSet.size === 0) {
+      resSet.add(480);
+      resSet.add(360);
+    }
+
+    const resolutions = Array.from(resSet).sort((a, b) => b - a);
+    return {
+      platform: 'facebook',
+      videoId: videoFBID || "",
+      canonicalUrl: videoFBID ? `https://www.facebook.com/watch/?v=${videoFBID}` : null,
+      resolutions: resolutions,
+      maxHeight: resolutions[0] || (isHD ? 1080 : 720),
+      isHD: isHD || (resolutions[0] >= 720),
+      duration: duration || 0,
+      title: document.title,
+      hdUrl: hdUrl,
+      sdUrl: sdUrl
+    };
+  }
+
+  // --- Master Reporting Function ---
   function reportMediaInfo() {
-    const info = getYouTubeMediaInfo();
-    if (info && info.levels && info.levels.length > 0) {
+    let info = null;
+    if (host.includes('youtube.com') || host.includes('youtu.be')) {
+      info = getYouTubeMediaInfo();
+    } else if (isFacebook) {
+      const activeVideo = document.querySelector('video[data-bdm-active="true"]') ||
+                          Array.from(document.querySelectorAll('video')).find(v => !v.paused && !v.ended && v.readyState > 1) ||
+                          document.querySelector('video');
+      info = getFacebookMediaInfo(activeVideo);
+    }
+
+    if (info) {
       window.postMessage({
         type: '__BDM_MEDIA_INFO__',
         data: info

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bengal DM Integration Module",
-  "version": "0.5",
+  "version": "0.6",
   "description": "Integrates your browser with Bengal Download Manager for fast, multi-threaded downloads.",
   "icons": {
     "16": "assets/icon-16.png",


### PR DESCRIPTION
## Summary

This pull request implements IDM-grade video resolution extraction specifically for Facebook (including Facebook Groups and Watch videos), enables default startup transparency for the floating media badge across all platforms, prefixes guessed media sizes with `~` across all sites while displaying exact file sizes without `~`, guarantees reliable dropdown closure on outside clicks or tab switching, and bumps the browser extension manifest to version `0.6`.

### 🌐 Browser Extension (v0.6)

- **Dropdown Closure on Outside Click & Tab Switching**:
  - Captures outside clicks and pointer-down interactions at the root `window` and `document` levels during the capture phase (`capture: true`), ensuring the dropdown closes even if page elements call `stopPropagation()`.
  - Added listeners for `document.visibilitychange`, `window.blur`, `window.pagehide`, and `chrome.tabs.onActivated` to ensure the extended resolution menu closes immediately when switching to another tab or window.
  - Added `Escape` key dismissal handler.

- **Guessed vs File Size Formatting Across All Sites**:
  - Prefixes guessed/estimated media file sizes (calculated via duration and bitrate or unknown duration) with `~` (e.g., `~ 14.2 MB`, `~ 1.2 GB`, `~ MB`).
  - When exact file byte size is known from the media server (e.g. `Content-Length` header captured by the background stream sniffer), displays the actual file size without `~` (e.g., `14.2 MB`).

- **Facebook Resolution Detection**:
  - Traverses React Fiber internals (`memoizedProps.coreVideoPlayerMetaData.videoFBID`, `dash_manifest`, representations) matching Tonec IDM integration techniques.
  - Generates accurate HD/SD resolution offerings (1080p, 720p HD, 480p, 360p) for Facebook video containers without getting truncated by initial adaptive player buffering.
  - Normalizes canonical video page links to `https://www.facebook.com/watch/?v=<fbid>`.
  - Strictly isolated to Facebook; YouTube API integration and generic sniffing on other platforms remain untouched.

- **Floating Media Popup Initial Transparency**:
  - Sets default widget opacity to `0.35` upon appearing for all videos across all websites.
  - Only shifts to full opacity (`1.0`) when hovered, focused, or interacted with via dropdown menu/dragging.

- **Manifest & Versioning**:
  - Bumped `extension/manifest.json` version from `0.5` to `0.6`.
  - Updated extension version reference in `docs/VERSIONING.md`.

### Verification

- Node.js syntax checks passed (`node --check extension/content.js extension/inject.js extension/background.js`).
- Full test suite passed (95 tests passed in pytest).
- Version manifest consistency verified (`python3 scripts/sync_version.py --check`).